### PR TITLE
fix: skip gif filtering

### DIFF
--- a/src/background/Prediction/Model.ts
+++ b/src/background/Prediction/Model.ts
@@ -49,15 +49,15 @@ export class Model implements IModel {
     const prediction = await this.model.classify(image, 1)
     const { result, className, probability } = this.handlePredictions([prediction])
 
-    if (this.settings.filteringGif && this.GIF_REGEX.test(url)) {
-      const predictionGIF = await this.model.classifyGif(image, { topk: 1, fps: 0.1 })
-      const { result, className, probability } = this.handlePredictions(predictionGIF)
-      this.logger.log(`GIF prediction for ${url} is ${className} ${probability}`)
-      this.LRUCache.set(url, result)
-      return result
-    }
+    // if (this.settings.filteringGif && this.GIF_REGEX.test(url)) {
+    //   const predictionGIF = await this.model.classifyGif(image, { topk: 1, fps: 0.1 })
+    //   const { result, className, probability } = this.handlePredictions(predictionGIF)
+    //   this.logger.log(`GIF prediction for ${url} is ${className} ${probability}`)
+    //   this.LRUCache.set(url, result)
+    //   return result
+    // }
 
-    this.logger.log(`IMG prediction for ${url} is ${className} ${probability}`)
+    this.logger.log(`IMG prediction is ${className} ${probability} for ${url}`)
     this.LRUCache.set(url, result)
     return result
   }

--- a/src/popup/components/Testing/index.tsx
+++ b/src/popup/components/Testing/index.tsx
@@ -6,7 +6,6 @@ import { useSelector, useDispatch } from 'react-redux'
 
 import {
   toggleLogging,
-  toggleGifFiltering,
   toggleDivFiltering,
   setTrainedModel,
   setFilterEffect,
@@ -25,7 +24,6 @@ export const Testing: React.FC = () => {
   const {
     logging,
     filteringDiv,
-    filteringGif,
     trainedModel,
     filterEffect,
     concurrency
@@ -89,11 +87,11 @@ export const Testing: React.FC = () => {
           onChange={() => dispatch(toggleDivFiltering())}
         >{'Filter backgroundImage of <div> tag'}</StyledCheckbox>
 
-        <StyledCheckbox
+        {/* <StyledCheckbox
           checked={filteringGif}
           style={{ marginLeft: 0, paddingTop: '7px' }}
           onChange={() => dispatch(toggleGifFiltering())}
-        >{'Filter GIF images'}</StyledCheckbox>
+        >{'Filter GIF images'}</StyledCheckbox> */}
       </CheckboxArea>
 
       <BugReport>


### PR DESCRIPTION
Not sure that we should filter gif images. Webpage sends gif url to background worker and after that it loads gif image, depends on size, but approx it takes 2-4 seconds(and 300ms to filter) for 1 gif image. So I decided to remove gif filtering in v1.3.0