### PR TITLE
Move jest-puppeter config from root

### DIFF
--- a/test/jest-puppeteer.config.js
+++ b/test/jest-puppeteer.config.js
@@ -1,5 +1,5 @@
 const { join } = require('path');
-const extensionPath = join(__dirname, './dist')
+const extensionPath = join(__dirname, '../dist')
 const options = {width: 900, height: 900}
 
 module.exports = {

--- a/test/jest.e2e.config.js
+++ b/test/jest.e2e.config.js
@@ -1,3 +1,5 @@
+process.env.JEST_PUPPETEER_CONFIG = require.resolve('./jest-puppeteer.config.js');
+
 module.exports = {
     testMatch: [ "**/test/e2e/**/*.[jt]s?(x)" ],
     verbose: true,


### PR DESCRIPTION
#### Changes
Move puppeteer jest config from root directory.
It's a bit weird way of setting up directory for config for jest-puppeteer
Fixes # cleaner root

#### Type of change
minor changes to e2e tests

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

