### PR TITLE
fix: set node version to 16 on release worlflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
       - name: Release
         uses: softprops/action-gh-release@v1
       - name: build


### PR DESCRIPTION
#### Changes

- On release workflow, set node version to `16` with `actions/setup-node@v1`.
- It is the same version as the one set on integrate workflow.

Fixes https://github.com/nsfw-filter/nsfw-filter/pull/231#issuecomment-1483701345

#### Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
