### PR TITLE
[ISSUE-244]Fix Instagram unhiden images under "hide" option

### DIFF
--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -39,14 +39,21 @@ export class DOMWatcher implements IDOMWatcher {
   private findAndCheckAllImages (element: Element): void {
     const images = element.getElementsByTagName('img')
     for (let i = 0; i < images.length; i++) {
-      this.imageFilter.analyzeImage(images[i], false, false)
+      this.imageFilter.analyzeImage(images[i], false)
     }
   }
 
   private checkAttributeMutation (mutation: MutationRecord): void {
     if ((mutation.target as HTMLImageElement).nodeName === 'IMG') {
+      const isSrcAttribute = mutation.attributeName === 'src'
       const isStyleAttribute = mutation.attributeName === 'style'
-      this.imageFilter.analyzeImage(mutation.target as HTMLImageElement, mutation.attributeName === 'src', isStyleAttribute)
+
+      if (isStyleAttribute) {
+        this.imageFilter.checkStyleMutation(mutation.target as HTMLImageElement)
+        return
+      }
+
+      this.imageFilter.analyzeImage(mutation.target as HTMLImageElement, isSrcAttribute)
     }
   }
 

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -39,13 +39,14 @@ export class DOMWatcher implements IDOMWatcher {
   private findAndCheckAllImages (element: Element): void {
     const images = element.getElementsByTagName('img')
     for (let i = 0; i < images.length; i++) {
-      this.imageFilter.analyzeImage(images[i], false)
+      this.imageFilter.analyzeImage(images[i], false, false)
     }
   }
 
   private checkAttributeMutation (mutation: MutationRecord): void {
     if ((mutation.target as HTMLImageElement).nodeName === 'IMG') {
-      this.imageFilter.analyzeImage(mutation.target as HTMLImageElement, mutation.attributeName === 'src')
+      const isStyleAttribute = mutation.attributeName === 'style'
+      this.imageFilter.analyzeImage(mutation.target as HTMLImageElement, mutation.attributeName === 'src', isStyleAttribute)
     }
   }
 
@@ -55,7 +56,7 @@ export class DOMWatcher implements IDOMWatcher {
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ['src']
+      attributeFilter: ['src', 'style']
     }
   }
 }

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -7,7 +7,7 @@ type imageFilterSettingsType = {
 }
 
 export type IImageFilter = {
-  analyzeImage: (image: HTMLImageElement, srcAttribute: boolean) => void
+  analyzeImage: (image: HTMLImageElement, srcAttribute: boolean, isStyleAttribute: boolean) => void
   setSettings: (settings: imageFilterSettingsType) => void
 }
 
@@ -26,9 +26,9 @@ export class ImageFilter extends Filter implements IImageFilter {
     this.settings = settings
   }
 
-  public analyzeImage (image: HTMLImageElement, srcAttribute: boolean = false): void {
+  public analyzeImage (image: HTMLImageElement, srcAttribute: boolean = false, isStyleAttribute: boolean): void {
     if (
-      (srcAttribute || image.dataset.nsfwFilterStatus === undefined) &&
+      (srcAttribute || isStyleAttribute || image.dataset.nsfwFilterStatus === undefined) &&
       image.src.length > 0 &&
       (
         (image.width > this.MIN_IMAGE_SIZE && image.height > this.MIN_IMAGE_SIZE) ||

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -7,8 +7,9 @@ type imageFilterSettingsType = {
 }
 
 export type IImageFilter = {
-  analyzeImage: (image: HTMLImageElement, srcAttribute: boolean, isStyleAttribute: boolean) => void
+  analyzeImage: (image: HTMLImageElement, srcAttribute: boolean) => void
   setSettings: (settings: imageFilterSettingsType) => void
+  checkStyleMutation: (image: HTMLImageElement) => void
 }
 
 export class ImageFilter extends Filter implements IImageFilter {
@@ -26,19 +27,34 @@ export class ImageFilter extends Filter implements IImageFilter {
     this.settings = settings
   }
 
-  public analyzeImage (image: HTMLImageElement, srcAttribute: boolean = false, isStyleAttribute: boolean): void {
-    if (
-      (srcAttribute || isStyleAttribute || image.dataset.nsfwFilterStatus === undefined) &&
-      image.src.length > 0 &&
-      (
-        (image.width > this.MIN_IMAGE_SIZE && image.height > this.MIN_IMAGE_SIZE) ||
-        image.height === 0 ||
-        image.width === 0
-      )
-    ) {
+  public analyzeImage (image: HTMLImageElement, srcAttribute: boolean = false): void {
+    const imageIsNotAnalyzed = srcAttribute || image.dataset.nsfwFilterStatus === undefined
+    const isImageValid = image.src.length > 0 && ((image.width > this.MIN_IMAGE_SIZE && image.height > this.MIN_IMAGE_SIZE) || image.height === 0 || image.width === 0)
+
+    if (imageIsNotAnalyzed && isImageValid) {
       image.dataset.nsfwFilterStatus = 'processing'
       this._analyzeImage(image)
     }
+  }
+
+  public checkStyleMutation (image: HTMLImageElement): void {
+    const isStyleOutdated = this.isStyleOutdated(image)
+
+    if (!isStyleOutdated) return
+
+    this.applyFilter(image, image.src)
+  }
+
+  private isStyleOutdated (image: HTMLImageElement): boolean {
+    const isImageNSFW = image.dataset.nsfwFilterStatus === 'nsfw'
+
+    if (!isImageNSFW) return false
+
+    const isVisibilityHiddenOutdated = this.settings.filterEffect === 'hide' && image.getAttribute('style')?.includes('visibility: hidden') === false
+    const isBlurOutdated = this.settings.filterEffect === 'blur' && image.getAttribute('style')?.includes('filter: blur') === false
+    const isGrayscaleOutdated = this.settings.filterEffect === 'grayscale' && image.getAttribute('style')?.includes('filter: grayscale') === false
+
+    return isVisibilityHiddenOutdated || isBlurOutdated || isGrayscaleOutdated
   }
 
   private _analyzeImage (image: HTMLImageElement): void {
@@ -48,13 +64,7 @@ export class ImageFilter extends Filter implements IImageFilter {
     this.requestToAnalyzeImage(request)
       .then(({ result, url }) => {
         if (result) {
-          if (this.settings.filterEffect === 'blur') {
-            image.style.filter = 'blur(25px)'
-            this.showImage(image, url)
-          } else if (this.settings.filterEffect === 'grayscale') {
-            image.style.filter = 'grayscale(1)'
-            this.showImage(image, url)
-          }
+          this.applyFilter(image, url)
 
           this.blockedItems++
           image.dataset.nsfwFilterStatus = 'nsfw'
@@ -64,6 +74,22 @@ export class ImageFilter extends Filter implements IImageFilter {
       }).catch(({ url }) => {
         this.showImage(image, url)
       })
+  }
+
+  private applyFilter (image: HTMLImageElement, url: string): void {
+    if (this.settings.filterEffect === 'blur') {
+      image.style.filter = 'blur(25px)'
+      this.showImage(image, url)
+      return
+    }
+
+    if (this.settings.filterEffect === 'grayscale') {
+      image.style.filter = 'grayscale(1)'
+      this.showImage(image, url)
+      return
+    }
+
+    this.hideImage(image)
   }
 
   private hideImage (image: HTMLImageElement): void {


### PR DESCRIPTION
#### Changes

Noticed instagram is modifying visibility inline style of images on each rendering, this cause the behaviour explained on the [issue 244](https://github.com/nsfw-filter/nsfw-filter/issues/244), where the hide option didn't works for Instagram.

In order to solve this on instagram and for another sites that could do the same, I added to the watcher to check if styles attribute was changed, and if it is, then apply again the `visibility: hidden` style, so we can overwrite the website `visibility: visible` style.  

Not sure why, it also fixes the issue https://github.com/nsfw-filter/nsfw-filter/issues/253, maybe related to Google modifying style attribute on the image

Fixes #244 #253 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Evidence

![imagen](https://github.com/nsfw-filter/nsfw-filter/assets/66505715/5c690254-9fd0-4b13-9084-fd829d5e5d7a)

![imagen](https://github.com/nsfw-filter/nsfw-filter/assets/66505715/3914d283-0682-469c-a340-aaab45e6630f)
