### PR TITLE
fix: hide scrollbar

### DIFF
--- a/src/popup/components/Footer/styles.ts
+++ b/src/popup/components/Footer/styles.ts
@@ -7,7 +7,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 12px 16px 14px 16px;
+  padding: 10px 16px 11px 16px;
   width: 100%;
 `
 

--- a/src/popup/components/Header/styles.ts
+++ b/src/popup/components/Header/styles.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
   border-bottom: 1px solid ${props => props.theme.border};
   display: flex;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: 11px 16px;
   width: 100%;
 `
 

--- a/src/popup/components/Production/styles.ts
+++ b/src/popup/components/Production/styles.ts
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 16px;
+  gap: 8px;
+  padding: 12px 16px;
   width: 100%;
 
   .ant-slider {
@@ -64,7 +64,7 @@ export const Card = styled.div`
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   padding: 14px;
 `
 
@@ -129,8 +129,8 @@ export const AdvancedToggle = styled.button`
 export const AdvancedPanel = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding-top: 12px;
+  gap: 10px;
+  padding-top: 10px;
 `
 
 export const AdvancedRow = styled.div`

--- a/src/popup/styles/Theme.tsx
+++ b/src/popup/styles/Theme.tsx
@@ -20,6 +20,30 @@ const GlobalStyle = createGlobalStyle`
     color: ${props => props.theme.text.primary};
     margin: 0;
   }
+  /* The popup content is tuned to fit under Chrome's ~600px popup cap, so this
+     scrollbar normally never appears. It's a fallback for when it does (long
+     locale, large default font): Chrome's default is a chunky grey gutter, so
+     replace it with a thin, rounded, floating thumb (transparent track; the 3px
+     transparent border + background-clip leaves a ~4px visible thumb). */
+  html {
+    scrollbar-width: thin;
+    scrollbar-color: ${props => props.theme.scrollbar.thumb} transparent;
+  }
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: ${props => props.theme.scrollbar.thumb};
+    border-radius: 999px;
+    border: 3px solid transparent;
+    background-clip: padding-box;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: ${props => props.theme.scrollbar.thumbHover};
+  }
 `
 
 const light = {
@@ -33,6 +57,10 @@ const light = {
   },
   accent: '#6366f1',
   border: '#ececf3',
+  scrollbar: {
+    thumb: '#d4d4e0',
+    thumbHover: '#b9b9c9'
+  },
   // The card surface is already near-white, so the default near-white track
   // vanishes into it. Sink the track a few shades and keep the selected thumb
   // pure white so the group reads as a distinct control.
@@ -54,6 +82,10 @@ const dark = {
   // Lighter indigo so the accent keeps contrast on the dark background.
   accent: '#818cf8',
   border: '#2c3742',
+  scrollbar: {
+    thumb: '#3a4651',
+    thumbHover: '#4a5765'
+  },
   segmented: {
     track: '#19222a',
     thumb: '#323f4a'

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -15,6 +15,10 @@ declare module 'styled-components' {
     }
     accent: string
     border: string
+    scrollbar: {
+      thumb: string
+      thumbHover: string
+    }
     segmented: {
       track: string
       thumb: string


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. --> 
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Hides scrollbar.

#### Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tightened spacing in the popup header, footer, and production panels for a more compact layout.
  * Added custom scrollbar styling with rounded thumbs and theme-aware colors in both light and dark modes.
  * Extended theme support to include scrollbar color values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->