### PR TITLE
fix: re-hide blocked images on style rewrite

### DIFF
--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -48,9 +48,17 @@ export class DOMWatcher implements IDOMWatcher {
   }
 
   private checkAttributeMutation (mutation: MutationRecord): void {
-    if ((mutation.target as HTMLImageElement).nodeName === 'IMG') {
-      this.imageFilter.analyzeImage(mutation.target as HTMLImageElement, mutation.attributeName === 'src')
+    if ((mutation.target as HTMLImageElement).nodeName !== 'IMG') return
+
+    const image = mutation.target as HTMLImageElement
+    // A style change is the page overwriting our effect (see checkStyleMutation),
+    // not a new image to classify.
+    if (mutation.attributeName === 'style') {
+      this.imageFilter.checkStyleMutation(image)
+      return
     }
+
+    this.imageFilter.analyzeImage(image, mutation.attributeName === 'src')
   }
 
   private static getConfig (): MutationObserverInit {
@@ -59,7 +67,7 @@ export class DOMWatcher implements IDOMWatcher {
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ['src']
+      attributeFilter: ['src', 'style']
     }
   }
 }

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -10,6 +10,7 @@ export type IImageFilter = {
   analyzeImage: (image: HTMLImageElement, srcAttribute: boolean) => void
   setSettings: (settings: imageFilterSettingsType) => void
   revealImage: (image: HTMLImageElement) => void
+  checkStyleMutation: (image: HTMLImageElement) => void
 }
 
 export class ImageFilter extends Filter implements IImageFilter {
@@ -78,6 +79,40 @@ export class ImageFilter extends Filter implements IImageFilter {
 
     image.dataset.nsfwFilterStatus = 'processing'
     this._analyzeImage(image)
+  }
+
+  // Some sites (Instagram, Google) rewrite an image's inline style on every
+  // re-render, wiping the effect we applied so a blocked image reappears. When
+  // the page clears the effect on a still-blocked image, put it back. The
+  // effect-intact check keeps this from looping against our own style writes.
+  public checkStyleMutation (image: HTMLImageElement): void {
+    if (image.dataset.nsfwFilterStatus !== 'nsfw') return
+    if (this.isEffectApplied(image)) return
+    this.applyEffect(image)
+  }
+
+  private isEffectApplied (image: HTMLImageElement): boolean {
+    // Match our exact value, not a substring: a site setting its own weak
+    // `filter: blur(1px)` on a blocked image must still count as effect-gone so
+    // we re-apply the full blur(25px), not leave the image barely obscured.
+    if (this.settings.filterEffect === 'blur') return image.style.filter === 'blur(25px)'
+    if (this.settings.filterEffect === 'grayscale') return image.style.filter === 'grayscale(1)'
+    return image.style.visibility === 'hidden'
+  }
+
+  private applyEffect (image: HTMLImageElement): void {
+    if (this.settings.filterEffect === 'blur') {
+      image.style.filter = 'blur(25px)'
+      image.style.visibility = 'visible'
+      if (image.parentNode?.nodeName === 'BODY') image.hidden = false
+    } else if (this.settings.filterEffect === 'grayscale') {
+      image.style.filter = 'grayscale(1)'
+      image.style.visibility = 'visible'
+      if (image.parentNode?.nodeName === 'BODY') image.hidden = false
+    } else {
+      image.style.visibility = 'hidden'
+      if (image.parentNode?.nodeName === 'BODY') image.hidden = true
+    }
   }
 
   private _analyzeImage (image: HTMLImageElement): void {

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -86,7 +86,15 @@ export class ImageFilter extends Filter implements IImageFilter {
   // the page clears the effect on a still-blocked image, put it back. The
   // effect-intact check keeps this from looping against our own style writes.
   public checkStyleMutation (image: HTMLImageElement): void {
-    if (image.dataset.nsfwFilterStatus !== 'nsfw') return
+    const status = image.dataset.nsfwFilterStatus
+    // An in-flight image is hidden only by our inline visibility; a restyle wipes
+    // it. Keep it hidden (not revealed-with-effect: it isn't classified yet) until
+    // the prediction returns and either reveals or blocks it.
+    if (status === 'processing') {
+      if (image.style.visibility !== 'hidden') this.hideImage(image)
+      return
+    }
+    if (status !== 'nsfw') return
     if (this.isEffectApplied(image)) return
     this.applyEffect(image)
   }

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -2,13 +2,15 @@
  * @jest-environment jsdom
  */
 import { DOMWatcher } from '../../src/content/DOMWatcher/DOMWatcher'
-import { IImageFilter } from '../../src/content/Filter/ImageFilter'
+import { IImageFilter, ImageFilter } from '../../src/content/Filter/ImageFilter'
 
 const flushMutations = async (): Promise<void> => await Promise.resolve()
 
 const makeFilter = (): IImageFilter => ({
   analyzeImage: jest.fn(),
-  setSettings: jest.fn()
+  setSettings: jest.fn(),
+  revealImage: jest.fn(),
+  checkStyleMutation: jest.fn()
 })
 
 afterEach(() => { document.body.innerHTML = '' })
@@ -45,5 +47,28 @@ describe('content => DOMWatcher => watch', () => {
     await flushMutations()
 
     expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'), true)
+  })
+})
+
+// Instagram (and Google) rewrite an image's inline style on every re-render,
+// wiping the effect we applied so the blocked image reappears. The observer has
+// to react to style changes, not just src, and re-apply the effect. Issue #244.
+describe('content => DOMWatcher => style rewrites (issue #244)', () => {
+  test('re-hides a blocked image after the page rewrites its style attribute', async () => {
+    document.body.innerHTML = '<img id="a" src="http://example.com/a.jpg" width="200" height="200">'
+    const image = document.getElementById('a') as HTMLImageElement
+    // Already classified nsfw and hidden, so the initial sweep skips it and no
+    // background prediction is needed for this test.
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.visibility = 'hidden'
+
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'hide' })
+    new DOMWatcher(filter).watch()
+
+    image.setAttribute('style', 'visibility: visible')
+    await flushMutations()
+
+    expect(image.style.visibility).toBe('hidden')
   })
 })

--- a/test/unit/ImageFilter.test.ts
+++ b/test/unit/ImageFilter.test.ts
@@ -104,6 +104,69 @@ describe('content => ImageFilter => analyzeImage', () => {
   })
 })
 
+describe('content => ImageFilter => checkStyleMutation', () => {
+  test('re-hides a blocked image whose visibility the page reset (hide mode)', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'hide' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.visibility = 'visible'
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.visibility).toBe('hidden')
+  })
+
+  test('re-applies blur whose filter the page cleared (blur mode)', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'blur' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.filter = ''
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.filter).toContain('blur')
+  })
+
+  test('restores full blur when the page downgrades it to a weak blur', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'blur' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.filter = 'blur(1px)'
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.filter).toBe('blur(25px)')
+  })
+
+  test('leaves an sfw image untouched', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'hide' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'sfw'
+    image.style.visibility = 'visible'
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.visibility).toBe('visible')
+  })
+
+  test('does not rewrite the style when the effect is still intact', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'hide' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.visibility = 'hidden'
+    const spy = jest.spyOn(image.style, 'visibility', 'set')
+
+    filter.checkStyleMutation(image)
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
 describe('content => ImageFilter => revealImage', () => {
   test('clears a blurred image and retags it sfw', () => {
     const image = makeImage(200, 200)

--- a/test/unit/ImageFilter.test.ts
+++ b/test/unit/ImageFilter.test.ts
@@ -141,6 +141,31 @@ describe('content => ImageFilter => checkStyleMutation', () => {
     expect(image.style.filter).toBe('blur(25px)')
   })
 
+  test('re-applies grayscale whose filter the page cleared (grayscale mode)', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'grayscale' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.filter = ''
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.filter).toBe('grayscale(1)')
+  })
+
+  test('keeps an in-flight image hidden rather than revealing it (blur mode)', () => {
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'blur' })
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'processing'
+    image.style.visibility = 'visible'
+
+    filter.checkStyleMutation(image)
+
+    expect(image.style.visibility).toBe('hidden')
+    expect(image.style.filter).not.toContain('blur')
+  })
+
   test('leaves an sfw image untouched', () => {
     const filter = new ImageFilter()
     filter.setSettings({ filterEffect: 'hide' })


### PR DESCRIPTION
#### Changes

Sites like Instagram and Google rewrite an image's inline `style` on every re-render. That wiped the effect we apply to a blocked image, so a NSFW image flashed back into view. The content script's `MutationObserver` only watched the `src` attribute, so it never saw the rewrite.

The observer now also watches `style`. When a page clears the effect on an image we've already classified NSFW, the content script re-applies it (blur, grayscale, or hide, per the setting). An effect-intact check stops it from looping against our own style writes, and it only acts on images tagged `nsfw`, so a right-click unhide is never reverted. The effect match is exact, so a site setting its own weak `blur(1px)` on a blocked image still gets the full `blur(25px)` back.

Verified live on instagram.com: a blocked image stays hidden through a style rewrite that previously revealed it. Unit tests cover the observer route and each effect mode.

Fixes #244

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image blocking is now resilient to page-driven inline style rewrites, so blocked images won’t accidentally become visible again when styles/visibility are changed.
  * When an image’s source or inline style is updated, the blocking effect is re-checked and re-applied as needed to maintain the expected hidden/blur/grayscale state.
  * Added coverage to ensure blocked, in-processing, and already-correct images are handled correctly during style changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->