### PR TITLE
feat: allowlist options page, live settings

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -36,6 +36,10 @@
     "default_title": "NSFW Filter",
     "default_popup": "src/popup.html"
   },
+  "options_ui": {
+    "page": "src/options.html",
+    "open_in_tab": true
+  },
   "icons": {
     "16": "images/icon16.png",
     "32": "images/icon32.png",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -102,18 +102,6 @@ const initRuntime = async (): Promise<Runtime> => {
   const { enabled, logging, filterStrictness, trainedModel } = store.getState().settings
   refreshActionBadge(enabled)
 
-  // reduxed keeps this worker's store synced with storage, so a popup toggle
-  // updates it even while the popup is open. Mirror `enabled` onto the badge
-  // live, guarding on change so per-image statistics ticks don't rewrite it.
-  let badgeEnabled = enabled
-  store.subscribe(() => {
-    const next = store.getState().settings.enabled
-    if (next !== badgeEnabled) {
-      badgeEnabled = next
-      refreshActionBadge(next)
-    }
-  })
-
   const logger = new Logger()
   if (logging === true) logger.enable()
 
@@ -121,6 +109,36 @@ const initRuntime = async (): Promise<Runtime> => {
   model.setSettings(filterStrictness, logging, trainedModel)
 
   const queue = new Queue(model, logger, store)
+
+  // reduxed keeps this worker's store synced with storage, so a popup change
+  // lands here even while the popup is open. Propagate live: mirror `enabled`
+  // onto the badge, and push model/strictness/logging to the offscreen document
+  // as they change (it swaps the model in place, gated on its prediction chain),
+  // clearing the cache so the new settings apply to already-seen images too.
+  // Guard on change so per-image statistics ticks don't trigger any of this.
+  let applied = { enabled, logging, filterStrictness, trainedModel }
+  store.subscribe(() => {
+    const next = store.getState().settings
+    if (next.enabled !== applied.enabled) refreshActionBadge(next.enabled)
+
+    if (
+      next.logging !== applied.logging ||
+      next.filterStrictness !== applied.filterStrictness ||
+      next.trainedModel !== applied.trainedModel
+    ) {
+      if (next.logging) logger.enable()
+      else logger.disable()
+      model.setSettings(next.filterStrictness, next.logging, next.trainedModel)
+      queue.clearCache()
+    }
+
+    applied = {
+      enabled: next.enabled,
+      logging: next.logging,
+      filterStrictness: next.filterStrictness,
+      trainedModel: next.trainedModel
+    }
+  })
 
   // The worker may have been restarted, losing the per-tab map. Reseed it from
   // the currently open tabs so in-flight prediction guards stay accurate.

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -113,8 +113,7 @@ const initRuntime = async (): Promise<Runtime> => {
   // reduxed keeps this worker's store synced with storage, so a popup change
   // lands here even while the popup is open. Propagate live: mirror `enabled`
   // onto the badge, and push model/strictness/logging to the offscreen document
-  // as they change (it swaps the model in place, gated on its prediction chain),
-  // clearing the cache so the new settings apply to already-seen images too.
+  // as they change (it swaps the model in place, gated on its prediction chain).
   // Guard on change so per-image statistics ticks don't trigger any of this.
   let applied = { enabled, logging, filterStrictness, trainedModel }
   store.subscribe(() => {
@@ -129,7 +128,11 @@ const initRuntime = async (): Promise<Runtime> => {
       if (next.logging) logger.enable()
       else logger.disable()
       model.setSettings(next.filterStrictness, next.logging, next.trainedModel)
-      queue.clearCache()
+      // Only a new verdict invalidates cached predictions; a logging toggle
+      // doesn't, so don't force re-classification of already-seen images for it.
+      if (next.filterStrictness !== applied.filterStrictness || next.trainedModel !== applied.trainedModel) {
+        queue.clearCache()
+      }
     }
 
     applied = {

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -10,23 +10,39 @@ import { IImageFilter } from '../Filter/ImageFilter'
 
 export type IDOMWatcher = {
   watch: () => void
+  unwatch: () => void
 }
 
 export class DOMWatcher implements IDOMWatcher {
   private readonly observer: MutationObserver
   private readonly imageFilter: IImageFilter
+  private watching: boolean
 
   constructor (imageFilter: IImageFilter) {
     this.imageFilter = imageFilter
     this.observer = new MutationObserver(this.callback.bind(this))
+    this.watching = false
   }
 
+  // Idempotent: a live enable toggle may call watch() on a page already being
+  // watched, and re-sweeping would re-run analyzeImage on every existing image.
   public watch (): void {
+    if (this.watching) return
+    this.watching = true
+
     this.observer.observe(document, DOMWatcher.getConfig())
     // The observer only reports future mutations. Sweep the images already in the
     // DOM so any image parsed before the (async) store resolved is still hidden
     // and classified instead of missed.
     this.findAndCheckAllImages(document.documentElement)
+  }
+
+  // Live pause / allow-list: stop reacting to the page so no new image gets
+  // hidden. Revealing the already-filtered ones is ImageFilter.revealAll's job.
+  public unwatch (): void {
+    if (!this.watching) return
+    this.watching = false
+    this.observer.disconnect()
   }
 
   private callback (mutationsList: MutationRecord[]): void {

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -11,6 +11,8 @@ export type IImageFilter = {
   setSettings: (settings: imageFilterSettingsType) => void
   revealImage: (image: HTMLImageElement) => void
   checkStyleMutation: (image: HTMLImageElement) => void
+  applyEffectToBlocked: () => void
+  revealAll: () => void
 }
 
 export class ImageFilter extends Filter implements IImageFilter {
@@ -97,6 +99,28 @@ export class ImageFilter extends Filter implements IImageFilter {
     if (status !== 'nsfw') return
     if (this.isEffectApplied(image)) return
     this.applyEffect(image)
+  }
+
+  // A live filterEffect change (blur -> grayscale -> hide) doesn't alter the
+  // NSFW verdict, only how it's shown, so re-render every already-blocked image
+  // from the current setting instead of reclassifying. applyEffect clears the
+  // other modes' styles, so switching modes doesn't leave a stale blur behind.
+  public applyEffectToBlocked (): void {
+    const blocked = document.querySelectorAll<HTMLImageElement>('img[data-nsfw-filter-status="nsfw"]')
+    blocked.forEach(image => this.applyEffect(image))
+  }
+
+  // Live pause / allow-list of the current page: bring back every image we
+  // touched. Clearing the status (not tagging sfw) means a later re-enable's
+  // sweep reclassifies them rather than trusting a verdict made while off.
+  public revealAll (): void {
+    const filtered = document.querySelectorAll<HTMLImageElement>('img[data-nsfw-filter-status]')
+    filtered.forEach(image => {
+      if (image.parentNode?.nodeName === 'BODY') image.hidden = false
+      image.style.filter = ''
+      image.style.visibility = 'visible'
+      delete image.dataset.nsfwFilterStatus
+    })
   }
 
   private isEffectApplied (image: HTMLImageElement): boolean {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -2,6 +2,8 @@ import { createStore } from 'redux'
 
 import { createChromeStore } from '../popup/redux/chrome-storage'
 import { rootReducer } from '../popup/redux/reducers'
+import { SettingsState } from '../popup/redux/reducers/settings'
+import { isHostAllowed } from '../utils/allowlist'
 import { CONTEXT_TARGET, UNHIDE_IMAGE, UnhideImageMessage } from '../utils/messages'
 
 import { DOMWatcher } from './DOMWatcher/DOMWatcher'
@@ -71,22 +73,54 @@ const init = (): void => {
   injectPendingHide()
   const safety = setTimeout(removePendingHide, HIDE_STYLE_SAFETY_TIMEOUT)
 
+  // Whether this page should be filtered right now, from a settings snapshot.
+  const shouldFilter = (settings: SettingsState): boolean =>
+    settings.enabled && !isHostAllowed(window.location.hostname, settings.websites)
+
   createChromeStore({ createStore })(rootReducer)
     .then(store => {
-      const { enabled, filterEffect, websites } = store.getState().settings
-      imageFilter.setSettings({ filterEffect })
-      const allowed = websites.includes(window.location.hostname)
-      if (enabled && !allowed) {
+      clearTimeout(safety)
+
+      let previous = store.getState().settings
+      imageFilter.setSettings({ filterEffect: previous.filterEffect })
+
+      let filtering = shouldFilter(previous)
+      if (filtering) {
         // Keep the pending-hide stylesheet in place: from here per-image tagging
         // governs visibility (and it also hides dynamically-added images before
         // the observer's callback can run hideImage).
-        clearTimeout(safety)
         domWatcher.watch()
       } else {
         // Extension turned off, or filtering disabled for this site: reveal everything.
-        clearTimeout(safety)
         removePendingHide()
       }
+
+      // reduxed keeps this store synced with chrome.storage, so a popup toggle or
+      // an allowlist edit lands here without a reload. React live: start/stop
+      // watching when on/off or the allowlist flips, and re-render already-blocked
+      // images when the effect changes (a new effect isn't a new verdict).
+      store.subscribe(() => {
+        const next = store.getState().settings
+        const prev = previous
+        previous = next
+
+        if (next.filterEffect !== prev.filterEffect) {
+          imageFilter.setSettings({ filterEffect: next.filterEffect })
+          if (filtering) imageFilter.applyEffectToBlocked()
+        }
+
+        const nextFiltering = shouldFilter(next)
+        if (nextFiltering === filtering) return
+        filtering = nextFiltering
+
+        if (filtering) {
+          domWatcher.watch()
+        } else {
+          domWatcher.unwatch()
+          removePendingHide()
+          imageFilter.revealAll()
+        }
+      })
     })
     .catch(error => {
       console.warn(error)

--- a/src/options/components/Options.tsx
+++ b/src/options/components/Options.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { setWebsiteList } from '../../popup/redux/actions/settings/index'
 import { RootState } from '../../popup/redux/reducers'
 import { SettingsState } from '../../popup/redux/reducers/settings'
-import { normalizeHostEntry } from '../../utils/allowlist'
+import { isHostAllowed, normalizeHostEntry } from '../../utils/allowlist'
 
 import { Wrap, Title, Sub, AddRow, ListCard, Row, Host, Remove, EmptyNote } from './styles'
 
@@ -19,7 +19,8 @@ export const Options: React.FC = () => {
     event.preventDefault()
     const entry = normalizeHostEntry(draft)
     if (entry === '') return
-    if (!websites.includes(entry)) dispatch(setWebsiteList([...websites, entry]))
+    // isHostAllowed, not includes: a broader entry already covers a subdomain.
+    if (!isHostAllowed(entry, websites)) dispatch(setWebsiteList([...websites, entry]))
     setDraft('')
   }
 

--- a/src/options/components/Options.tsx
+++ b/src/options/components/Options.tsx
@@ -1,0 +1,62 @@
+import { Button, Input } from 'antd'
+import { Trash2 } from 'lucide-react'
+import React, { useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { setWebsiteList } from '../../popup/redux/actions/settings/index'
+import { RootState } from '../../popup/redux/reducers'
+import { SettingsState } from '../../popup/redux/reducers/settings'
+import { normalizeHostEntry } from '../../utils/allowlist'
+
+import { Wrap, Title, Sub, AddRow, ListCard, Row, Host, Remove, EmptyNote } from './styles'
+
+export const Options: React.FC = () => {
+  const dispatch = useDispatch()
+  const { websites } = useSelector<RootState>((state) => state.settings) as SettingsState
+  const [draft, setDraft] = useState('')
+
+  const add = (event: React.FormEvent): void => {
+    event.preventDefault()
+    const entry = normalizeHostEntry(draft)
+    if (entry === '') return
+    if (!websites.includes(entry)) dispatch(setWebsiteList([...websites, entry]))
+    setDraft('')
+  }
+
+  const remove = (entry: string): void => {
+    dispatch(setWebsiteList(websites.filter(site => site !== entry)))
+  }
+
+  return (
+    <Wrap>
+      <Title>Allowed sites</Title>
+      <Sub>
+        NSFW Filter leaves these sites unfiltered. A domain also covers its
+        subdomains, so allowing example.com covers www.example.com. You can also
+        allow the current site in one click from the toolbar popup.
+      </Sub>
+
+      <AddRow onSubmit={add}>
+        <Input
+          placeholder="example.com"
+          value={draft}
+          onChange={event => setDraft(event.target.value)}
+        />
+        <Button type="primary" htmlType="submit">Add</Button>
+      </AddRow>
+
+      <ListCard>
+        {websites.length === 0
+          ? <EmptyNote>No allowed sites yet. Every site is filtered.</EmptyNote>
+          : websites.map(entry => (
+            <Row key={entry}>
+              <Host>{entry}</Host>
+              <Remove onClick={() => remove(entry)} aria-label={`Remove ${entry}`}>
+                <Trash2 size={16} />
+              </Remove>
+            </Row>
+          ))}
+      </ListCard>
+    </Wrap>
+  )
+}

--- a/src/options/components/styles.ts
+++ b/src/options/components/styles.ts
@@ -1,0 +1,76 @@
+import styled from 'styled-components'
+
+export const Wrap = styled.div`
+  margin: 0 auto;
+  max-width: 560px;
+  padding: 48px 24px 64px;
+`
+
+export const Title = styled.h1`
+  color: ${props => props.theme.text.primary};
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+`
+
+export const Sub = styled.p`
+  color: ${props => props.theme.text.secondary};
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 8px 0 24px;
+`
+
+export const AddRow = styled.form`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+`
+
+export const ListCard = styled.div`
+  background-color: ${props => props.theme.bg.surface};
+  border: 1px solid ${props => props.theme.border};
+  border-radius: 12px;
+  overflow: hidden;
+`
+
+export const Row = styled.div`
+  align-items: center;
+  border-top: 1px solid ${props => props.theme.border};
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 16px;
+
+  &:first-child {
+    border-top: none;
+  }
+`
+
+export const Host = styled.span`
+  color: ${props => props.theme.text.primary};
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+export const Remove = styled.button`
+  align-items: center;
+  background: none;
+  border: none;
+  color: ${props => props.theme.text.secondary};
+  cursor: pointer;
+  display: flex;
+  padding: 4px;
+
+  &:hover {
+    color: ${props => props.theme.accent};
+  }
+`
+
+export const EmptyNote = styled.div`
+  color: ${props => props.theme.text.secondary};
+  font-size: 14px;
+  padding: 24px 16px;
+  text-align: center;
+`

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -1,0 +1,24 @@
+import { createRoot } from 'react-dom/client'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+
+import { createChromeStore } from '../popup/redux/chrome-storage'
+import { rootReducer } from '../popup/redux/reducers'
+import { Theme } from '../popup/styles/Theme'
+
+import { Options } from './components/Options'
+
+;(async () => {
+  const store = await createChromeStore({ createStore })(rootReducer)
+
+  const container = document.getElementById('options')
+  if (container === null) return
+
+  createRoot(container).render(
+    <Provider store={store}>
+      <Theme>
+        <Options />
+      </Theme>
+    </Provider>
+  )
+})()

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>NSFW Filter options</title>
+    </head>
+    <body>
+        <div id="options"></div>
+        <script src="options.js"></script>
+    </body>
+</html>

--- a/src/popup/components/Production/AllowSiteField.tsx
+++ b/src/popup/components/Production/AllowSiteField.tsx
@@ -1,0 +1,63 @@
+import { Switch } from 'antd'
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { isHostAllowed, normalizeHostEntry } from '../../../utils/allowlist'
+import { setWebsiteList } from '../../redux/actions/settings/index'
+import { RootState } from '../../redux/reducers'
+import { SettingsState } from '../../redux/reducers/settings'
+
+import { AllowRow, AllowText, AllowHost, FieldLabel } from './styles'
+
+// The active tab's host, or '' on a page with no filterable host (chrome://,
+// the new-tab page, extension pages) where allow-listing makes no sense.
+const useCurrentHost = (): string | null => {
+  const [host, setHost] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    chrome.tabs.query({ active: true, currentWindow: true })
+      .then(([tab]) => {
+        if (!active) return
+        try {
+          setHost(tab?.url ? new URL(tab.url).hostname : '')
+        } catch {
+          setHost('')
+        }
+      })
+      .catch(() => { if (active) setHost('') })
+    return () => { active = false }
+  }, [])
+
+  return host
+}
+
+export const AllowSiteField: React.FC = () => {
+  const dispatch = useDispatch()
+  const { websites } = useSelector<RootState>((state) => state.settings) as SettingsState
+  const host = useCurrentHost()
+
+  const allowed = host !== null && host !== '' && isHostAllowed(host, websites)
+
+  const onToggle = (allow: boolean): void => {
+    if (host === null || host === '') return
+    if (allow) {
+      const entry = normalizeHostEntry(host)
+      if (entry !== '' && !websites.includes(entry)) dispatch(setWebsiteList([...websites, entry]))
+    } else {
+      // Drop every entry that currently covers this host, including a broader
+      // parent-domain entry, so the toggle actually re-enables filtering here.
+      dispatch(setWebsiteList(websites.filter(entry => !isHostAllowed(host, [entry]))))
+    }
+  }
+
+  return (
+    <AllowRow>
+      <AllowText>
+        <FieldLabel>Allow this site</FieldLabel>
+        <AllowHost>{host === null ? '…' : host === '' ? 'Not available on this page' : host}</AllowHost>
+      </AllowText>
+      <Switch checked={allowed} disabled={host === null || host === ''} onChange={onToggle} />
+    </AllowRow>
+  )
+}

--- a/src/popup/components/Production/index.tsx
+++ b/src/popup/components/Production/index.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Input, Segmented, Select, Slider, Switch } from 'antd'
+import { Checkbox, Segmented, Select, Slider, Switch } from 'antd'
 import { ChevronDown, ChevronUp, Contrast, Droplet, EyeOff } from 'lucide-react'
 import React, { useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
@@ -8,7 +8,6 @@ import { setFilterStrictness } from '../../redux/actions/settings'
 import {
   setTrainedModel,
   setFilterEffect,
-  setWebsiteList,
   toggleEnabled,
   toggleLogging
 } from '../../redux/actions/settings/index'
@@ -16,6 +15,7 @@ import { RootState } from '../../redux/reducers'
 import { SettingsState } from '../../redux/reducers/settings'
 import { StatisticsState } from '../../redux/reducers/statistics'
 
+import { AllowSiteField } from './AllowSiteField'
 import {
   Container,
   Stat,
@@ -32,6 +32,7 @@ import {
   FieldLabel,
   FieldValue,
   SliderEnds,
+  ManageLink,
   AdvancedToggle,
   AdvancedPanel,
   AdvancedRow
@@ -45,7 +46,6 @@ export const Production: React.FC = () => {
     filterStrictness,
     trainedModel,
     filterEffect,
-    websites,
     logging
   } = useSelector<RootState>((state) => state.settings) as SettingsState
   const { totalBlocked } = useSelector<RootState>((state) => state.statistics) as StatisticsState
@@ -99,15 +99,10 @@ export const Production: React.FC = () => {
           />
         </EffectField>
 
-        <Field>
-          <FieldLabel>Allowed sites</FieldLabel>
-          <Input
-            style={{ marginTop: 8 }}
-            placeholder="twitter.com, facebook.com"
-            defaultValue={websites.join(', ')}
-            onChange={event => dispatch(setWebsiteList(event.target.value.split(/\s*,\s*/).filter(Boolean)))}
-          />
-        </Field>
+        <AllowSiteField />
+        <ManageLink onClick={() => chrome.runtime.openOptionsPage()}>
+          Manage allowed sites
+        </ManageLink>
       </Card>
 
       <div>

--- a/src/popup/components/Production/styles.ts
+++ b/src/popup/components/Production/styles.ts
@@ -109,6 +109,44 @@ export const SliderEnds = styled.div`
   margin-top: -2px;
 `
 
+export const AllowRow = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+`
+
+export const AllowText = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+`
+
+export const AllowHost = styled.span`
+  color: ${props => props.theme.text.secondary};
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+export const ManageLink = styled.button`
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: ${props => props.theme.accent};
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 2px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
 export const AdvancedToggle = styled.button`
   align-items: center;
   background: none;

--- a/src/utils/allowlist.ts
+++ b/src/utils/allowlist.ts
@@ -1,0 +1,39 @@
+// The allowlist is a set of hosts the user has chosen to leave unfiltered. It's
+// edited from the popup (one-click "allow this site") and the options page, and
+// read by the content script to decide whether to filter the current page. Both
+// storing and matching go through here so a host is normalized the same way
+// wherever it enters.
+
+// Reduce any user input (a bare host, a full URL, a pasted address) to a bare
+// registrable-ish host. A leading `www.` is dropped so `www.example.com` and
+// `example.com` collapse to one entry, and isHostAllowed's subdomain rule then
+// covers the `www.` visit anyway.
+export const normalizeHostEntry = (input: string): string => {
+  let host = input.trim().toLowerCase()
+  if (host === '') return ''
+
+  try {
+    if (/^[a-z][a-z0-9+.-]*:\/\//.test(host)) host = new URL(host).hostname
+    else host = host.split('/')[0]
+  } catch {
+    host = host.split('/')[0]
+  }
+
+  host = host.split(':')[0]
+  if (host.startsWith('www.')) host = host.slice(4)
+  return host
+}
+
+// A page is allowed when its host equals an entry or is a subdomain of one. The
+// dot in `.${entry}` is what stops `evilexample.com` from matching `example.com`
+// while still letting `m.example.com` through.
+export const isHostAllowed = (hostname: string, websites: string[]): boolean => {
+  const host = hostname.trim().toLowerCase()
+  if (host === '') return false
+
+  return websites.some(entry => {
+    const allowed = normalizeHostEntry(entry)
+    if (allowed === '') return false
+    return host === allowed || host.endsWith(`.${allowed}`)
+  })
+}

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -50,6 +50,35 @@ describe('content => DOMWatcher => watch', () => {
   })
 })
 
+// Live enable/disable and allowlist toggles have to start and stop watching on
+// an already-open page without a reload, so watch() must be idempotent and
+// unwatch() must stop reporting future mutations.
+describe('content => DOMWatcher => start/stop live', () => {
+  test('sweeps existing images once even if watch() is called twice', () => {
+    document.body.innerHTML = '<img id="a">'
+    const filter = makeFilter()
+
+    const watcher = new DOMWatcher(filter)
+    watcher.watch()
+    watcher.watch()
+
+    expect(filter.analyzeImage).toHaveBeenCalledTimes(1)
+  })
+
+  test('unwatch stops reacting to later mutations', async () => {
+    const filter = makeFilter()
+    const watcher = new DOMWatcher(filter)
+    watcher.watch()
+    watcher.unwatch();
+    (filter.analyzeImage as jest.Mock).mockClear()
+
+    document.body.appendChild(document.createElement('img'))
+    await flushMutations()
+
+    expect(filter.analyzeImage).not.toHaveBeenCalled()
+  })
+})
+
 // Instagram (and Google) rewrite an image's inline style on every re-render,
 // wiping the effect we applied so the blocked image reappears. The observer has
 // to react to style changes, not just src, and re-apply the effect. Issue #244.

--- a/test/unit/ImageFilter.test.ts
+++ b/test/unit/ImageFilter.test.ts
@@ -192,6 +192,58 @@ describe('content => ImageFilter => checkStyleMutation', () => {
   })
 })
 
+// Live filterEffect changes must re-render already-blocked images without
+// re-running classification (the verdict hasn't changed, only its presentation).
+describe('content => ImageFilter => applyEffectToBlocked', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  test('re-renders blocked images from blur to grayscale', () => {
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.filter = 'blur(25px)'
+    document.body.appendChild(image)
+
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'grayscale' })
+    filter.applyEffectToBlocked()
+
+    expect(image.style.filter).toBe('grayscale(1)')
+  })
+
+  test('leaves sfw images untouched', () => {
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'sfw'
+    image.style.filter = ''
+    document.body.appendChild(image)
+
+    const filter = new ImageFilter()
+    filter.setSettings({ filterEffect: 'grayscale' })
+    filter.applyEffectToBlocked()
+
+    expect(image.style.filter).toBe('')
+  })
+})
+
+// Pausing the extension or allow-listing the site mid-page must bring already
+// blocked images back, and clear their status so re-enabling reclassifies them.
+describe('content => ImageFilter => revealAll', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  test('reveals every blocked image and clears its status', () => {
+    const image = makeImage(200, 200)
+    image.dataset.nsfwFilterStatus = 'nsfw'
+    image.style.filter = 'blur(25px)'
+    image.style.visibility = 'hidden'
+    document.body.appendChild(image)
+
+    new ImageFilter().revealAll()
+
+    expect(image.style.filter).toBe('')
+    expect(image.style.visibility).toBe('visible')
+    expect(image.dataset.nsfwFilterStatus).toBeUndefined()
+  })
+})
+
 describe('content => ImageFilter => revealImage', () => {
   test('clears a blurred image and retags it sfw', () => {
     const image = makeImage(200, 200)

--- a/test/unit/allowlist.test.ts
+++ b/test/unit/allowlist.test.ts
@@ -1,0 +1,51 @@
+import { isHostAllowed, normalizeHostEntry } from '../../src/utils/allowlist'
+
+describe('utils => allowlist => normalizeHostEntry', () => {
+  test('lowercases the host', () => {
+    expect(normalizeHostEntry('Example.COM')).toBe('example.com')
+  })
+
+  test('strips protocol, path, and query', () => {
+    expect(normalizeHostEntry('https://example.com/some/path?q=1')).toBe('example.com')
+  })
+
+  test('drops a leading www. so it dedupes against the bare domain', () => {
+    expect(normalizeHostEntry('www.example.com')).toBe('example.com')
+  })
+
+  test('trims surrounding whitespace', () => {
+    expect(normalizeHostEntry('   example.com  ')).toBe('example.com')
+  })
+
+  test('returns an empty string for input with no host', () => {
+    expect(normalizeHostEntry('')).toBe('')
+    expect(normalizeHostEntry('   ')).toBe('')
+  })
+})
+
+describe('utils => allowlist => isHostAllowed', () => {
+  test('matches an exact hostname', () => {
+    expect(isHostAllowed('example.com', ['example.com'])).toBe(true)
+  })
+
+  test('matches a subdomain of an allowed entry', () => {
+    expect(isHostAllowed('www.example.com', ['example.com'])).toBe(true)
+    expect(isHostAllowed('m.example.com', ['example.com'])).toBe(true)
+  })
+
+  test('does not match a lookalike domain that only ends with the entry text', () => {
+    expect(isHostAllowed('evilexample.com', ['example.com'])).toBe(false)
+  })
+
+  test('does not match an unrelated host', () => {
+    expect(isHostAllowed('other.com', ['example.com'])).toBe(false)
+  })
+
+  test('tolerates un-normalized stored entries', () => {
+    expect(isHostAllowed('www.example.com', ['https://www.Example.com/'])).toBe(true)
+  })
+
+  test('an empty allowlist allows nothing', () => {
+    expect(isHostAllowed('example.com', [])).toBe(false)
+  })
+})

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -12,6 +12,7 @@ module.exports = {
         background: `${PATHS.src}/background/background.ts`,
         offscreen: `${PATHS.src}/offscreen/offscreen.ts`,
         popup: `${PATHS.src}/popup/index.tsx`,
+        options: `${PATHS.src}/options/index.tsx`,
     },
     output: {
         path: PATHS.dist,
@@ -45,6 +46,7 @@ module.exports = {
         new CopyPlugin({
             patterns: [
                 { from: `${PATHS.src}/popup/popup.html`, to: PATHS.dist },
+                { from: `${PATHS.src}/options/options.html`, to: PATHS.dist },
                 { from: `${PATHS.src}/offscreen/offscreen.html`, to: PATHS.dist },
                 // TensorFlow.js WASM backend binaries, loaded via setWasmPaths()
                 {


### PR DESCRIPTION
#### Changes

Moves the allowlist out of the comma-separated text box into a real options page, adds a one-click way to allow the current site from the popup, and makes settings apply to open tabs without a reload.

- Options page (opens in a tab) manages the allowlist as an add/remove list instead of a comma box.
- Popup gets an "Allow this site" toggle for the current tab plus a "Manage allowed sites" link to the options page.
- Allowlist matches host and subdomains, so `example.com` covers `www.example.com` but not `evilexample.com`. The logic lives in `src/utils/allowlist.ts` and is shared by the options manager, the popup toggle, and the content gate.
- Enable/disable, allowlist edits, filter effect, logging, strictness, and the model switch now apply live via `store.subscribe` (reduxed keeps every context synced with `chrome.storage`), so no page or extension reload is needed. The content script starts/stops filtering and re-renders already-blocked images in place; the background pushes model/strictness/logging to the offscreen document, which swaps the model warm.

No new permissions: the popup reads the active tab host under the existing `<all_urls>` host permission. Nothing fetches at runtime.

Verified headed on a real GPU: options add/remove persists, live allowlist reveal, live blur to grayscale, and a live model swap logging `model: MobileNet_v1.2` on WebGL. 46 unit tests pass, eslint is clean.

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an options page for managing allowed sites.
  * Added an “Allow this site” control in the popup.
  * Added a link from the popup to the options page.

* **Bug Fixes**
  * Settings changes now apply immediately (no reload).
  * Updating the filter effect refreshes already-blocked images.
  * Page monitoring can now be paused/resumed cleanly.

* **Improvements**
  * Allowed sites are normalized consistently with subdomain matching.
  * Clearing/removing allowlisted sites reveals hidden content and resets its state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->