### PR TITLE
fix: never leave a page blank when there is no usable GPU

### DIFF
--- a/src/background/Queue/PredictionQueue.ts
+++ b/src/background/Queue/PredictionQueue.ts
@@ -67,9 +67,9 @@ export class PredictionQueue extends QueueBase {
   private onFailure ({ url, error }: OnFailureParam): void {
     if (!this._checkUrlStatus(url)) return
 
-    // Deliberately not cached. A failure means we never got a verdict -- usually
-    // the model being unavailable, not the image being safe -- so caching it as
-    // `false` would keep serving "safe" for that URL for the rest of the session.
+    // Not cached. A failure means no verdict, usually an unavailable model rather
+    // than a safe image, so caching `false` would keep serving "safe" for that URL
+    // until the entry is evicted.
 
     for (const [{ reject }] of this.requestMap.get(url) as requestQueueValue) {
       reject(error)

--- a/src/background/Queue/PredictionQueue.ts
+++ b/src/background/Queue/PredictionQueue.ts
@@ -67,7 +67,9 @@ export class PredictionQueue extends QueueBase {
   private onFailure ({ url, error }: OnFailureParam): void {
     if (!this._checkUrlStatus(url)) return
 
-    this.cache.set(url, false)
+    // Deliberately not cached. A failure means we never got a verdict -- usually
+    // the model being unavailable, not the image being safe -- so caching it as
+    // `false` would keep serving "safe" for that URL for the rest of the session.
 
     for (const [{ reject }] of this.requestMap.get(url) as requestQueueValue) {
       reject(error)

--- a/src/content/Filter/Filter.ts
+++ b/src/content/Filter/Filter.ts
@@ -15,13 +15,10 @@ type FilterRequestQueueValue = {
   request: PredictionRequest
 }
 
-// Nothing downstream is guaranteed to answer. The service worker can be torn
-// down mid-request, and an offscreen document whose TensorFlow.js backend wedged
-// never replies at all. The image stays hidden until this promise settles, so
-// without a deadline here one stuck classification leaves it hidden for the life
-// of the page. Reveal it instead: showing an unclassified image is a bad
-// outcome, but a permanently blank page is a worse one, and it matches how the
-// rest of the filter degrades when it can't get a verdict.
+// An image stays hidden until its prediction settles, and nothing downstream is
+// guaranteed to answer: the service worker can be torn down mid-request, and an
+// offscreen document whose TensorFlow.js backend wedged never replies. Reveal the
+// image rather than leave it hidden for the life of the page.
 const ANALYSIS_DEADLINE = 60000
 
 export class Filter implements IFilter {
@@ -65,9 +62,8 @@ export class Filter implements IFilter {
     })
   }
 
-  // Take the pending entry for `url` off the queue and stop its timers. Returns
-  // undefined when it was already settled, which is how a reply that arrives
-  // after we gave up gets dropped instead of resolving twice.
+  // Takes the pending entry off the queue and stops its timers. undefined means it
+  // was already settled, which is how a reply that arrives too late is dropped.
   private _take (url: string): FilterRequestQueueValue | undefined {
     const queued = this.requestQueue.get(url)
     if (queued === undefined) return undefined
@@ -79,10 +75,14 @@ export class Filter implements IFilter {
     return queued
   }
 
-  // Same, for a reply belonging to a specific request. The same url can be queued
-  // again after one times out, so a late reply must not settle the new entry.
+  // A url can be queued again after a request is abandoned, so a reply or a retry
+  // has to prove it still belongs to the entry on the queue.
+  private _isCurrent (request: PredictionRequest): boolean {
+    return this.requestQueue.get(request.url)?.request === request
+  }
+
   private _takeFor (request: PredictionRequest): FilterRequestQueueValue | undefined {
-    if (this.requestQueue.get(request.url)?.request !== request) return undefined
+    if (!this._isCurrent(request)) return undefined
 
     return this._take(request.url)
   }
@@ -112,6 +112,10 @@ export class Filter implements IFilter {
   }
 
   private _handleBackgroundErrors (request: PredictionRequest, message: string | undefined): void {
+    // A sendMessage callback can't be cancelled, so this still fires for a request
+    // we gave up on. Nothing is waiting on it; don't restart the retry loop.
+    if (!this._isCurrent(request)) return
+
     const reconnectCount = request.clearTimer()
     console.log(`[NSFW-Filter] Cannot connect to background worker for ${request.url} image, attempt ${reconnectCount}, error: ${message}`)
 

--- a/src/content/Filter/Filter.ts
+++ b/src/content/Filter/Filter.ts
@@ -4,10 +4,25 @@ type IFilter = {
   getBlockAmount: () => number
 }
 
-type FilterRequestQueueValue = Array<Array<{
+type FilterRequestWaiter = {
   resolve: (value: PredictionResponse) => void
   reject: (error: PredictionRequest) => void
-}>>
+}
+
+type FilterRequestQueueValue = {
+  waiters: FilterRequestWaiter[]
+  deadline: number
+  request: PredictionRequest
+}
+
+// Nothing downstream is guaranteed to answer. The service worker can be torn
+// down mid-request, and an offscreen document whose TensorFlow.js backend wedged
+// never replies at all. The image stays hidden until this promise settles, so
+// without a deadline here one stuck classification leaves it hidden for the life
+// of the page. Reveal it instead: showing an unclassified image is a bad
+// outcome, but a permanently blank page is a worse one, and it matches how the
+// rest of the filter degrades when it can't get a verdict.
+const ANALYSIS_DEADLINE = 60000
 
 export class Filter implements IFilter {
   protected blockedItems: number
@@ -27,52 +42,89 @@ export class Filter implements IFilter {
       const queueName = request.url
 
       try {
-        if (this.requestQueue.has(queueName)) {
-          this.requestQueue.get(queueName)?.push([{ resolve, reject }])
+        const queued = this.requestQueue.get(queueName)
+        if (queued !== undefined) {
+          queued.waiters.push({ resolve, reject })
         } else {
-          this.requestQueue.set(queueName, [[{ resolve, reject }]])
+          this.requestQueue.set(queueName, {
+            waiters: [{ resolve, reject }],
+            deadline: window.setTimeout(() => this._giveUp(queueName), ANALYSIS_DEADLINE),
+            request
+          })
 
-          this._requestToAnalyzeImage(request, resolve)
+          this._requestToAnalyzeImage(request)
         }
       } catch {
-        if (this.requestQueue.has(queueName)) {
-          for (const [{ reject }] of this.requestQueue.get(queueName) as FilterRequestQueueValue) {
-            reject(request)
-          }
+        const pending = this._take(queueName)
+        if (pending !== undefined) {
+          for (const { reject } of pending.waiters) reject(request)
         } else {
           reject(request)
         }
-
-        this.requestQueue.delete(queueName)
       }
     })
   }
 
-  private _requestToAnalyzeImage (request: PredictionRequest, resolve: (value: PredictionResponse) => void): void {
+  // Take the pending entry for `url` off the queue and stop its timers. Returns
+  // undefined when it was already settled, which is how a reply that arrives
+  // after we gave up gets dropped instead of resolving twice.
+  private _take (url: string): FilterRequestQueueValue | undefined {
+    const queued = this.requestQueue.get(url)
+    if (queued === undefined) return undefined
+
+    window.clearTimeout(queued.deadline)
+    window.clearTimeout(queued.request.reconectTimer)
+    this.requestQueue.delete(url)
+
+    return queued
+  }
+
+  // Same, for a reply belonging to a specific request. The same url can be queued
+  // again after one times out, so a late reply must not settle the new entry.
+  private _takeFor (request: PredictionRequest): FilterRequestQueueValue | undefined {
+    if (this.requestQueue.get(request.url)?.request !== request) return undefined
+
+    return this._take(request.url)
+  }
+
+  private _giveUp (url: string): void {
+    const pending = this._take(url)
+    if (pending === undefined) return
+
+    console.warn(`[NSFW-Filter] No verdict for ${url} after ${ANALYSIS_DEADLINE}ms, marked as visible`)
+    for (const { resolve } of pending.waiters) {
+      resolve(new PredictionResponse(false, url, 'Analysis timed out'))
+    }
+  }
+
+  private _requestToAnalyzeImage (request: PredictionRequest): void {
     chrome.runtime.sendMessage(request, (response: PredictionResponse) => {
       if (chrome.runtime.lastError !== null && chrome.runtime.lastError !== undefined) {
-        this._handleBackgroundErrors(request, resolve, chrome.runtime.lastError.message)
+        this._handleBackgroundErrors(request, chrome.runtime.lastError.message)
         return
       }
 
-      for (const [{ resolve }] of this.requestQueue.get(request.url) as FilterRequestQueueValue) {
-        resolve(response)
-      }
+      const pending = this._takeFor(request)
+      if (pending === undefined) return
 
-      this.requestQueue.delete(request.url)
+      for (const { resolve } of pending.waiters) resolve(response)
     })
   }
 
-  private _handleBackgroundErrors (request: PredictionRequest, resolve: (value: PredictionResponse) => void, message: string | undefined): void {
+  private _handleBackgroundErrors (request: PredictionRequest, message: string | undefined): void {
     const reconnectCount = request.clearTimer()
     console.log(`[NSFW-Filter] Cannot connect to background worker for ${request.url} image, attempt ${reconnectCount}, error: ${message}`)
 
     if (reconnectCount > 5) {
-      resolve(new PredictionResponse(false, request.url, 'Background worker doesn\'t working'))
+      const pending = this._takeFor(request)
+      if (pending === undefined) return
+
       console.warn(`[NSFW-Filter] Background worker is down, marked as visible ${request.url}`)
-      this.requestQueue.delete(request.url)
+      for (const { resolve } of pending.waiters) {
+        resolve(new PredictionResponse(false, request.url, 'Background worker doesn\'t working'))
+      }
     } else {
-      request.reconectTimer = window.setTimeout(() => this._requestToAnalyzeImage(request, resolve), 500)
+      request.reconectTimer = window.setTimeout(() => this._requestToAnalyzeImage(request), 500)
     }
   }
 }

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -3,8 +3,8 @@
 // service worker forwards every image URL here; we load it, classify it, and
 // return a boolean. We prefer the WebGL (GPU) backend, the one the MV2 background
 // page used, and fall back to single-threaded WASM (CPU) when no usable GPU is
-// available. See trySetWebglBackend() and setWasmBackend() for the CSP details,
-// and restartOnWasm() for why the fallback reloads the document.
+// available. trySetWebglBackend() and setWasmBackend() cover the CSP details, and
+// restartOnWasm() covers why the fallback reloads the document.
 //
 // This file owns the shared tfjs backend and serializes work; the actual model
 // (weights, preprocessing, decision) lives behind a Classifier so the user can
@@ -24,6 +24,7 @@ import { withTimeout } from '../utils/withTimeout'
 import { BinaryClassifier } from './classifiers/BinaryClassifier'
 import { Classifier } from './classifiers/Classifier'
 import { NsfwjsClassifier } from './classifiers/NsfwjsClassifier'
+import { readRestartState, saveRestartState } from './restartState'
 
 const IMAGE_SIZE = 224
 const LOADING_TIMEOUT = 1000
@@ -40,50 +41,20 @@ const WEBGL_PROBE_TIMEOUT = 3000
 // script's pending-hide stylesheet would leave them hidden). On timeout the
 // prediction rejects, the image is revealed, and the chain is freed.
 const PREDICTION_TIMEOUT = 10000
-// Bringing the WASM backend up fetches and compiles a .wasm binary, so it is
-// slower than the WebGL probe and needs its own bound.
+// Fetching and compiling the .wasm binary is slower than probing WebGL.
 const WASM_INIT_TIMEOUT = 15000
 
-// Anything that goes wrong on WebGL leaves work we cannot cancel: a probe or a
-// warm-up that timed out is still running on the GPU, and switching the live tfjs
-// engine to WASM waits on it forever, so every queued image stays hidden. Drop the
-// realm instead -- reload the offscreen document and come straight up on WASM.
-// What the reloaded document needs is written to sessionStorage first: the
-// settings, which the still-running service worker won't push again, and the fact
-// that it is a restart, so it skips WebGL instead of looping through the same
-// failure.
-const RESTART_KEY = 'nsfw-filter-restart'
-
-type RestartState = {
-  filterStrictness: number
-  trainedModel: TrainedModel
-  logging: boolean
-}
-
-const readRestartState = (): RestartState | null => {
-  const saved = sessionStorage.getItem(RESTART_KEY)
-  if (saved === null) return null
-
-  try {
-    return JSON.parse(saved) as RestartState
-  } catch (error) {
-    logger.error(error as Error)
-    return null
-  }
-}
-
-const restartState = readRestartState()
+const restartState = readRestartState(sessionStorage, logger)
 
 // Switch TensorFlow.js to the WebGL (GPU) backend, the one the MV2 background
 // page used by default. The MV3 CSP only forbids JS eval; the WebGL backend
 // compiles GLSL shaders on the GPU instead of evaluating JS, so it stays
 // CSP-safe. Returns true if WebGL registered and a small GPU op round-trips;
-// false (without throwing) if anything fails or hangs, so the caller can restart
-// on WASM.
+// false (without throwing) if anything fails or hangs, so the caller can restart.
 const trySetWebglBackend = async (): Promise<boolean> => {
   try {
-    // setBackend resolves false when asynchronous initialisation fails, so trust
-    // the boolean and getBackend() rather than calling tf.ready() after it.
+    // setBackend resolves false when async initialisation fails, so trust the
+    // boolean and getBackend() rather than calling tf.ready() after it.
     if (!(await withTimeout(setBackend('webgl'), WEBGL_PROBE_TIMEOUT, 'WebGL setBackend'))) return false
     // setBackend('webgl') can register but still fail or hang on the first real
     // op if the context is unusable. Run a small computation and read it back
@@ -124,9 +95,9 @@ let restarting = false
 const ensureBackend = async (): Promise<void> => {
   if (currentBackend !== null) return
 
-  // Only a document that has already restarted goes straight to WASM. A first
-  // attempt that fails restarts rather than switching the engine in place, since
-  // trySetWebglBackend also returns false when it times out.
+  // Only an already-restarted document goes straight to WASM. A first attempt that
+  // fails restarts instead, since trySetWebglBackend also returns false on a
+  // timeout, and the timed-out work is still holding the GPU.
   if (restartState === null) {
     if (await trySetWebglBackend()) {
       currentBackend = 'webgl'
@@ -135,23 +106,25 @@ const ensureBackend = async (): Promise<void> => {
     restartOnWasm()
   }
 
-  // Throw rather than leave currentBackend claiming a backend that isn't active:
-  // bringUpClassifier retries, and once it gives up every classification rejects
-  // and the content script reveals the images instead of holding them hidden.
+  // Throw rather than leave currentBackend claiming a backend that isn't active.
+  // bringUpClassifier retries, then every classification rejects and the content
+  // script reveals the images.
   if (!(await setWasmBackend())) throw new Error('No usable TensorFlow.js backend')
   currentBackend = 'wasm'
 }
 
-// Come back up in a clean realm on WASM. reload() only schedules the navigation,
-// so throw as well rather than carrying on in a realm that is about to go away.
-// In-flight classifications are dropped and the content script reveals those images.
+// A WebGL probe or warm-up that timed out is still running on the GPU, and
+// switching the live tfjs engine to WASM waits on it forever, so come back up in a
+// clean realm instead. reload() only schedules the navigation, so throw as well
+// rather than carry on in a realm about to go away. In-flight classifications are
+// dropped and the content script reveals those images.
 const restartOnWasm = (): never => {
   restarting = true
-  sessionStorage.setItem(RESTART_KEY, JSON.stringify({
+  saveRestartState(sessionStorage, {
     filterStrictness: pendingStrictness,
     trainedModel: pendingModelId,
     logging: pendingLogging
-  }))
+  })
   location.reload()
 
   throw new Error('Restarting the offscreen document on WASM')
@@ -190,9 +163,8 @@ const createClassifier = (id: TrainedModel): Classifier => {
   return new NsfwjsClassifier(logger, settings)
 }
 
-// Load a model on the current backend, with the retry the single-model version
-// used. A model that can't warm up on WebGL restarts the document on WASM, so the
-// GPU path can't wedge.
+// Load a model on the current backend, retrying as the single-model version did.
+// A model that can't come up on WebGL restarts the document on WASM instead.
 const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
   await ensureBackend()
 
@@ -200,10 +172,9 @@ const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
   while (true) {
     try {
       const classifier = createClassifier(id)
-      // Require warm-up on every backend. On WebGL a failed warm-up returns false
-      // (not throw) so we can restart on WASM; on WASM a failed warm-up must also
-      // fail here, so bringUpOrFallback can try the default model instead of
-      // accepting a model that can't actually run.
+      // Warm up on every backend so a model that can't run is never accepted. On
+      // WASM the failure has to throw, so bringUpOrFallback tries the default
+      // model instead.
       const ok = await classifier.load(true)
       if (!ok && currentBackend === 'webgl') {
         logger.log('WebGL cannot run the model; restarting the offscreen document on WASM')
@@ -216,13 +187,18 @@ const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
       logger.log(`TFJS backend: ${currentBackend}, model: ${id}`)
       return classifier
     } catch (error) {
-      // A restart is already scheduled; retrying here would just load the model
-      // again on the backend that can't run it, in a realm about to be dropped.
+      // A restart is already scheduled; retrying would reload the model on the
+      // backend that can't run it, in a realm about to be dropped.
       if (restarting) throw error
       attempts++
       logger.error(error as Error)
       logger.log(`Reload model, attempt: ${attempts}`)
-      if (attempts >= MAX_LOAD_ATTEMPTS) throw error
+      // Out of retries on WebGL. A load that keeps failing there may be waiting on
+      // GPU work we can't cancel, so drop the realm rather than report no model.
+      if (attempts >= MAX_LOAD_ATTEMPTS) {
+        if (currentBackend === 'webgl') restartOnWasm()
+        throw error
+      }
       await new Promise(resolve => setTimeout(resolve, 200))
     }
   }
@@ -234,7 +210,7 @@ const bringUpOrFallback = async (id: TrainedModel): Promise<Classifier> => {
   try {
     return await bringUpClassifier(id)
   } catch (error) {
-    if (id === DEFAULT_TRAINED_MODEL) throw error
+    if (restarting || id === DEFAULT_TRAINED_MODEL) throw error
     logger.error(error as Error)
     logger.log(`Model ${id} failed to load; falling back to ${DEFAULT_TRAINED_MODEL}`)
     return await bringUpClassifier(DEFAULT_TRAINED_MODEL)

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -3,13 +3,14 @@
 // service worker forwards every image URL here; we load it, classify it, and
 // return a boolean. We prefer the WebGL (GPU) backend, the one the MV2 background
 // page used, and fall back to single-threaded WASM (CPU) when no usable GPU is
-// available. See trySetWebglBackend() and setWasmBackend() for the CSP details.
+// available. See trySetWebglBackend() and setWasmBackend() for the CSP details,
+// and restartOnWasm() for why the fallback reloads the document.
 //
 // This file owns the shared tfjs backend and serializes work; the actual model
 // (weights, preprocessing, decision) lives behind a Classifier so the user can
 // switch between models. Switching disposes one Classifier and loads another.
 
-import { enableProdMode, env as tfEnv, getBackend, ready as tfReady, setBackend, tensor1d, tidy } from '@tensorflow/tfjs'
+import { enableProdMode, env as tfEnv, getBackend, setBackend, tensor1d, tidy } from '@tensorflow/tfjs'
 import { setWasmPaths } from '@tensorflow/tfjs-backend-wasm'
 
 import { Logger } from '../utils/Logger'
@@ -39,17 +40,51 @@ const WEBGL_PROBE_TIMEOUT = 3000
 // script's pending-hide stylesheet would leave them hidden). On timeout the
 // prediction rejects, the image is revealed, and the chain is freed.
 const PREDICTION_TIMEOUT = 10000
+// Bringing the WASM backend up fetches and compiles a .wasm binary, so it is
+// slower than the WebGL probe and needs its own bound.
+const WASM_INIT_TIMEOUT = 15000
+
+// Anything that goes wrong on WebGL leaves work we cannot cancel: a probe or a
+// warm-up that timed out is still running on the GPU, and switching the live tfjs
+// engine to WASM waits on it forever, so every queued image stays hidden. Drop the
+// realm instead -- reload the offscreen document and come straight up on WASM.
+// What the reloaded document needs is written to sessionStorage first: the
+// settings, which the still-running service worker won't push again, and the fact
+// that it is a restart, so it skips WebGL instead of looping through the same
+// failure.
+const RESTART_KEY = 'nsfw-filter-restart'
+
+type RestartState = {
+  filterStrictness: number
+  trainedModel: TrainedModel
+  logging: boolean
+}
+
+const readRestartState = (): RestartState | null => {
+  const saved = sessionStorage.getItem(RESTART_KEY)
+  if (saved === null) return null
+
+  try {
+    return JSON.parse(saved) as RestartState
+  } catch (error) {
+    logger.error(error as Error)
+    return null
+  }
+}
+
+const restartState = readRestartState()
 
 // Switch TensorFlow.js to the WebGL (GPU) backend, the one the MV2 background
 // page used by default. The MV3 CSP only forbids JS eval; the WebGL backend
 // compiles GLSL shaders on the GPU instead of evaluating JS, so it stays
 // CSP-safe. Returns true if WebGL registered and a small GPU op round-trips;
-// false (without throwing) if anything fails or hangs, so the caller can fall
-// back to WASM.
+// false (without throwing) if anything fails or hangs, so the caller can restart
+// on WASM.
 const trySetWebglBackend = async (): Promise<boolean> => {
   try {
+    // setBackend resolves false when asynchronous initialisation fails, so trust
+    // the boolean and getBackend() rather than calling tf.ready() after it.
     if (!(await withTimeout(setBackend('webgl'), WEBGL_PROBE_TIMEOUT, 'WebGL setBackend'))) return false
-    await tfReady()
     // setBackend('webgl') can register but still fail or hang on the first real
     // op if the context is unusable. Run a small computation and read it back
     // from the GPU to prove the path works. tidy() returns the result tensor, so
@@ -73,30 +108,64 @@ const trySetWebglBackend = async (): Promise<boolean> => {
 // from blob: URLs, which the MV3 CSP blocks, and needs cross-origin isolation
 // the offscreen document lacks. One thread is enough for the single image we
 // classify at a time.
-const setWasmBackend = async (): Promise<void> => {
+const setWasmBackend = async (): Promise<boolean> => {
   setWasmPaths(chrome.runtime.getURL('src/'))
   tfEnv().set('WASM_HAS_MULTITHREAD_SUPPORT', false)
-  await setBackend('wasm')
-  await tfReady()
+
+  const ok = await withTimeout(setBackend('wasm'), WASM_INIT_TIMEOUT, 'WASM backend')
+  return ok && getBackend() === 'wasm'
 }
 
-// The tfjs backend is global and picked once: try WebGL, else WASM. A later
-// per-model fallback can still drop WebGL->WASM if a specific model can't run
-// on the GPU (see bringUpClassifier).
+// The tfjs backend is global and picked once per document: WebGL, or WASM after a
+// restart. It is never switched in place; see restartOnWasm.
 let currentBackend: 'webgl' | 'wasm' | null = null
+let restarting = false
 
 const ensureBackend = async (): Promise<void> => {
   if (currentBackend !== null) return
-  currentBackend = (await trySetWebglBackend()) ? 'webgl' : 'wasm'
-  if (currentBackend === 'wasm') await setWasmBackend()
+
+  // Only a document that has already restarted goes straight to WASM. A first
+  // attempt that fails restarts rather than switching the engine in place, since
+  // trySetWebglBackend also returns false when it times out.
+  if (restartState === null) {
+    if (await trySetWebglBackend()) {
+      currentBackend = 'webgl'
+      return
+    }
+    restartOnWasm()
+  }
+
+  // Throw rather than leave currentBackend claiming a backend that isn't active:
+  // bringUpClassifier retries, and once it gives up every classification rejects
+  // and the content script reveals the images instead of holding them hidden.
+  if (!(await setWasmBackend())) throw new Error('No usable TensorFlow.js backend')
+  currentBackend = 'wasm'
+}
+
+// Come back up in a clean realm on WASM. reload() only schedules the navigation,
+// so throw as well rather than carrying on in a realm that is about to go away.
+// In-flight classifications are dropped and the content script reveals those images.
+const restartOnWasm = (): never => {
+  restarting = true
+  sessionStorage.setItem(RESTART_KEY, JSON.stringify({
+    filterStrictness: pendingStrictness,
+    trainedModel: pendingModelId,
+    logging: pendingLogging
+  }))
+  location.reload()
+
+  throw new Error('Restarting the offscreen document on WASM')
 }
 
 // --- The active model and the work queue ----------------------------------
 
 let activeClassifier: Classifier | null = null
 let bringingUp = false
-let pendingStrictness = DEFAULT_FILTER_STRICTNESS
-let pendingModelId: TrainedModel = DEFAULT_TRAINED_MODEL
+let pendingStrictness = restartState?.filterStrictness ?? DEFAULT_FILTER_STRICTNESS
+let pendingModelId: TrainedModel = restartState?.trainedModel ?? DEFAULT_TRAINED_MODEL
+let pendingLogging = restartState?.logging ?? false
+
+if (pendingLogging) logger.enable()
 
 // Serialise predictions AND model switches on one chain so a switch never
 // disposes a model out from under an in-flight prediction (model concurrency =
@@ -121,27 +190,24 @@ const createClassifier = (id: TrainedModel): Classifier => {
   return new NsfwjsClassifier(logger, settings)
 }
 
-// Load a model on the current backend, with the same WebGL->WASM fallback and
-// retry the single-model version used. A model that can't warm up on WebGL is
-// disposed (inside load) and reloaded on WASM, so the GPU path can't wedge.
+// Load a model on the current backend, with the retry the single-model version
+// used. A model that can't warm up on WebGL restarts the document on WASM, so the
+// GPU path can't wedge.
 const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
   await ensureBackend()
 
   let attempts = 0
   while (true) {
     try {
-      let classifier = createClassifier(id)
+      const classifier = createClassifier(id)
       // Require warm-up on every backend. On WebGL a failed warm-up returns false
-      // (not throw) so we can drop to WASM; on WASM a failed warm-up must also
+      // (not throw) so we can restart on WASM; on WASM a failed warm-up must also
       // fail here, so bringUpOrFallback can try the default model instead of
       // accepting a model that can't actually run.
-      let ok = await classifier.load(true)
+      const ok = await classifier.load(true)
       if (!ok && currentBackend === 'webgl') {
-        logger.log('WebGL cannot run the model; falling back to WASM')
-        currentBackend = 'wasm'
-        await setWasmBackend()
-        classifier = createClassifier(id)
-        ok = await classifier.load(true)
+        logger.log('WebGL cannot run the model; restarting the offscreen document on WASM')
+        restartOnWasm()
       }
       if (!ok) {
         classifier.dispose()
@@ -150,6 +216,9 @@ const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
       logger.log(`TFJS backend: ${currentBackend}, model: ${id}`)
       return classifier
     } catch (error) {
+      // A restart is already scheduled; retrying here would just load the model
+      // again on the backend that can't run it, in a realm about to be dropped.
+      if (restarting) throw error
       attempts++
       logger.error(error as Error)
       logger.log(`Reload model, attempt: ${attempts}`)
@@ -239,7 +308,8 @@ chrome.runtime.onMessage.addListener((
   if (message.type === 'SET_SETTINGS') {
     pendingStrictness = message.filterStrictness
     pendingModelId = message.trainedModel
-    if (message.logging) logger.enable()
+    pendingLogging = message.logging
+    if (pendingLogging) logger.enable()
     else logger.disable()
 
     ensureUp()

--- a/src/offscreen/restartState.ts
+++ b/src/offscreen/restartState.ts
@@ -1,0 +1,35 @@
+import { ILogger } from '../utils/Logger'
+import { TrainedModel } from '../utils/models'
+
+// The offscreen document cannot switch the TensorFlow.js backend in place, so it
+// reloads itself onto WASM instead (see restartOnWasm in offscreen.ts). The
+// reloaded document has no way back to the settings the service worker pushed,
+// because the worker is still running and won't push them again, so they are
+// handed over through sessionStorage.
+export const RESTART_KEY = 'nsfw-filter-restart'
+
+export type RestartState = {
+  filterStrictness: number
+  trainedModel: TrainedModel
+  logging: boolean
+}
+
+export const saveRestartState = (storage: Storage, state: RestartState): void => {
+  storage.setItem(RESTART_KEY, JSON.stringify(state))
+}
+
+// null means a first start, so the caller brings the document up on WebGL. A
+// record we can't parse is treated the same way rather than trusted: coming up on
+// defaults classifies images, and reloading again on a record that will never
+// parse would not.
+export const readRestartState = (storage: Storage, logger: ILogger): RestartState | null => {
+  const saved = storage.getItem(RESTART_KEY)
+  if (saved === null) return null
+
+  try {
+    return JSON.parse(saved) as RestartState
+  } catch (error) {
+    logger.error(error as Error)
+    return null
+  }
+}

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -33,7 +33,10 @@ const resolveChromePath = () => {
   ].map(parts => path.join(cache, build, ...parts)).find(p => fs.existsSync(p))
 }
 
-const launchOptions = () => ({
+// `webgl: false` drops the software-GL flags and turns GL off entirely, so the
+// offscreen document has to bring the model up on the WASM backend instead --
+// the path a machine with no usable GPU takes.
+const launchOptions = ({ webgl = true } = {}) => ({
   headless: process.env.HEADLESS !== 'false',
   executablePath: resolveChromePath(),
   defaultViewport: null,
@@ -45,10 +48,10 @@ const launchOptions = () => ({
     '--no-sandbox',
     '--disable-setuid-sandbox',
     '--disable-dev-shm-usage',
-    // The model runs on WebGL; force a software backend so it works without a GPU.
-    '--enable-unsafe-swiftshader',
-    '--use-gl=angle',
-    '--use-angle=swiftshader'
+    ...(webgl
+      // The model runs on WebGL; force a software backend so it works without a GPU.
+      ? ['--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader']
+      : ['--disable-gpu', '--disable-software-rasterizer', '--use-gl=disabled'])
   ]
 })
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -33,9 +33,9 @@ const resolveChromePath = () => {
   ].map(parts => path.join(cache, build, ...parts)).find(p => fs.existsSync(p))
 }
 
-// `webgl: false` drops the software-GL flags and turns GL off entirely, so the
-// offscreen document has to bring the model up on the WASM backend instead --
-// the path a machine with no usable GPU takes.
+// `webgl: false` turns GL off entirely instead of enabling software GL, so the
+// offscreen document has to come up on WASM, the path a machine with no usable
+// GPU takes.
 const launchOptions = ({ webgl = true } = {}) => ({
   headless: process.env.HEADLESS !== 'false',
   executablePath: resolveChromePath(),

--- a/test/e2e/noGpuFallback.test.js
+++ b/test/e2e/noGpuFallback.test.js
@@ -1,0 +1,69 @@
+// Every other e2e test launches Chrome with software WebGL, so the WASM backend
+// the offscreen document falls back to on a machine with no usable GPU was never
+// exercised. That path used to wedge: bringing the backend up never settled, the
+// serialised op chain stayed blocked behind it, and the content script left every
+// image tagged `processing` and hidden by its own inline style. Launch a browser
+// with GL off and prove the page still settles.
+
+// WASM inference is much slower than WebGL, so allow more time to settle than the
+// WebGL tests need before calling it a hang. Deliberately shorter than the content
+// script's 60s analysis deadline: if the page only settled because that deadline
+// fired, the images were revealed unclassified and this should still fail.
+const SETTLE_TIMEOUT = 40000
+
+// Set by the offscreen document when it drops a realm it can't run the model in.
+const RESTART_KEY = 'nsfw-filter-restart'
+
+describe('No usable GPU', () => {
+  let page
+
+  beforeAll(async () => {
+    page = await global.__BROWSER_NO_GPU__.newPage()
+    await page.goto(global.__BASE_URL__, { waitUntil: 'domcontentloaded' })
+  }, SETTLE_TIMEOUT)
+
+  afterAll(async () => {
+    await page.close()
+  })
+
+  // Guards the guard: without this the suite would silently pass on WebGL if a
+  // future Chrome ignored the flags, testing nothing.
+  test('runs without WebGL, so the model has to load on WASM', async () => {
+    const webgl = await page.evaluate(() =>
+      document.createElement('canvas').getContext('webgl') !== null
+    )
+    expect(webgl).toBe(false)
+  })
+
+  test('settles every image instead of leaving the page blank', async () => {
+    await page.waitForFunction(() =>
+      [...document.images].every(image => {
+        const status = image.getAttribute('data-nsfw-filter-status')
+        return status !== null && status !== 'processing'
+      }),
+    { timeout: SETTLE_TIMEOUT, polling: 500 })
+
+    const hidden = await page.evaluate(() =>
+      [...document.images].filter(image => getComputedStyle(image).visibility === 'hidden').length
+    )
+    expect(hidden).toBe(0)
+  })
+
+  // The offscreen document reaches WASM by restarting itself, not by switching the
+  // live tfjs engine. Read its sessionStorage to prove the restart happened and
+  // that the document came back up rather than reloading in a loop.
+  test('gets to WASM by restarting the offscreen document once', async () => {
+    const offscreen = global.__BROWSER_NO_GPU__.targets()
+      .find(target => target.url().endsWith('/src/offscreen.html'))
+    expect(offscreen).toBeDefined()
+
+    const session = await offscreen.createCDPSession()
+    const { result } = await session.send('Runtime.evaluate', {
+      expression: `sessionStorage.getItem('${RESTART_KEY}')`,
+      returnByValue: true
+    })
+    await session.detach()
+
+    expect(result.value).not.toBeNull()
+  })
+})

--- a/test/e2e/noGpuFallback.test.js
+++ b/test/e2e/noGpuFallback.test.js
@@ -1,18 +1,33 @@
-// Every other e2e test launches Chrome with software WebGL, so the WASM backend
-// the offscreen document falls back to on a machine with no usable GPU was never
-// exercised. That path used to wedge: bringing the backend up never settled, the
-// serialised op chain stayed blocked behind it, and the content script left every
-// image tagged `processing` and hidden by its own inline style. Launch a browser
-// with GL off and prove the page still settles.
+// Every other e2e test launches Chrome with software WebGL, so the WASM fallback
+// was never exercised. That path used to wedge: the backend never came up, the
+// serialised op chain stayed blocked behind it, and every image stayed tagged
+// `processing` and hidden. Launch a browser with GL off and prove it settles.
 
-// WASM inference is much slower than WebGL, so allow more time to settle than the
-// WebGL tests need before calling it a hang. Deliberately shorter than the content
-// script's 60s analysis deadline: if the page only settled because that deadline
-// fired, the images were revealed unclassified and this should still fail.
+// WASM inference is much slower than WebGL, so allow more time before calling it a
+// hang. Deliberately shorter than the content script's 60s analysis deadline: a
+// page that only settled because the deadline fired must still fail here.
 const SETTLE_TIMEOUT = 40000
 
 // Set by the offscreen document when it drops a realm it can't run the model in.
 const RESTART_KEY = 'nsfw-filter-restart'
+
+const serviceWorker = async () =>
+  await global.__BROWSER_NO_GPU__.waitForTarget(
+    target => target.type() === 'service_worker',
+    { timeout: SETTLE_TIMEOUT }
+  )
+
+const evaluateIn = async (target, expression) => {
+  const session = await target.createCDPSession()
+  const { result } = await session.send('Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true
+  })
+  await session.detach()
+
+  return result.value
+}
 
 describe('No usable GPU', () => {
   let page
@@ -26,8 +41,8 @@ describe('No usable GPU', () => {
     await page.close()
   })
 
-  // Guards the guard: without this the suite would silently pass on WebGL if a
-  // future Chrome ignored the flags, testing nothing.
+  // Without this the suite would silently pass on WebGL, testing nothing, if a
+  // future Chrome ignored the flags.
   test('runs without WebGL, so the model has to load on WASM', async () => {
     const webgl = await page.evaluate(() =>
       document.createElement('canvas').getContext('webgl') !== null
@@ -36,6 +51,9 @@ describe('No usable GPU', () => {
   })
 
   test('settles every image instead of leaving the page blank', async () => {
+    // Without an image on the page the settle check below is vacuously true.
+    expect(await page.evaluate(() => document.images.length)).toBeGreaterThan(0)
+
     await page.waitForFunction(() =>
       [...document.images].every(image => {
         const status = image.getAttribute('data-nsfw-filter-status')
@@ -49,21 +67,43 @@ describe('No usable GPU', () => {
     expect(hidden).toBe(0)
   })
 
-  // The offscreen document reaches WASM by restarting itself, not by switching the
-  // live tfjs engine. Read its sessionStorage to prove the restart happened and
-  // that the document came back up rather than reloading in a loop.
-  test('gets to WASM by restarting the offscreen document once', async () => {
+  // The offscreen document reaches WASM by restarting itself, carrying its settings
+  // through sessionStorage (restartState.test.ts covers that round-trip). A single
+  // `reload` navigation proves it restarted once rather than looping through the
+  // same failure.
+  test('gets to WASM by restarting the offscreen document', async () => {
     const offscreen = global.__BROWSER_NO_GPU__.targets()
       .find(target => target.url().endsWith('/src/offscreen.html'))
     expect(offscreen).toBeDefined()
 
-    const session = await offscreen.createCDPSession()
-    const { result } = await session.send('Runtime.evaluate', {
-      expression: `sessionStorage.getItem('${RESTART_KEY}')`,
-      returnByValue: true
-    })
-    await session.detach()
+    const restart = JSON.parse(
+      await evaluateIn(offscreen, `sessionStorage.getItem('${RESTART_KEY}')`)
+    )
+    const navigations = await evaluateIn(
+      offscreen,
+      "performance.getEntriesByType('navigation').map(entry => entry.type)"
+    )
 
-    expect(result.value).not.toBeNull()
+    expect(restart).toEqual({
+      filterStrictness: expect.any(Number),
+      trainedModel: expect.any(String),
+      logging: expect.any(Boolean)
+    })
+    expect(navigations).toEqual(['reload'])
+  })
+
+  // The background reports a failed prediction as `false`, the same verdict this
+  // fixture expects, so a settled page can't tell inference from failing open. Ask
+  // the offscreen document directly and require an error-free answer.
+  test('classifies on WASM instead of failing open', async () => {
+    const response = await evaluateIn(
+      await serviceWorker(),
+      `new Promise(resolve => chrome.runtime.sendMessage(
+        { target: 'offscreen', type: 'CLASSIFY', url: '${global.__BASE_URL__}icon.png' },
+        resolve
+      ))`
+    )
+
+    expect(response).toEqual({ result: false })
   })
 })

--- a/test/jest.e2e.global_setup.js
+++ b/test/jest.e2e.global_setup.js
@@ -14,9 +14,16 @@ module.exports = async function () {
   const browser = await puppeteer.launch(launchOptions())
   global.__BROWSER_GLOBAL__ = browser
 
-  // Hand the wsEndpoint and fixture URL to the per-file test environments.
+  // A second browser with GL off, for the tests that need the WASM backend the
+  // extension falls back to when there is no usable GPU. Test files can't launch
+  // it themselves: jest doesn't transform their requires, and puppeteer is ESM.
+  const noGpuBrowser = await puppeteer.launch(launchOptions({ webgl: false }))
+  global.__BROWSER_NO_GPU_GLOBAL__ = noGpuBrowser
+
+  // Hand the wsEndpoints and fixture URL to the per-file test environments.
   fs.mkdirSync(DIR, { recursive: true })
   fs.writeFileSync(path.join(DIR, 'wsEndpoint'), browser.wsEndpoint())
+  fs.writeFileSync(path.join(DIR, 'wsEndpointNoGpu'), noGpuBrowser.wsEndpoint())
   fs.writeFileSync(path.join(DIR, 'baseUrl'), baseUrl)
 
   // Give the service worker and offscreen document time to warm up the model.

--- a/test/jest.e2e.global_setup.js
+++ b/test/jest.e2e.global_setup.js
@@ -14,9 +14,9 @@ module.exports = async function () {
   const browser = await puppeteer.launch(launchOptions())
   global.__BROWSER_GLOBAL__ = browser
 
-  // A second browser with GL off, for the tests that need the WASM backend the
-  // extension falls back to when there is no usable GPU. Test files can't launch
-  // it themselves: jest doesn't transform their requires, and puppeteer is ESM.
+  // A second browser with GL off, for the tests that need the WASM fallback. Test
+  // files can't launch it themselves: jest doesn't transform their requires, and
+  // puppeteer is ESM.
   const noGpuBrowser = await puppeteer.launch(launchOptions({ webgl: false }))
   global.__BROWSER_NO_GPU_GLOBAL__ = noGpuBrowser
 

--- a/test/jest.e2e.global_teardown.js
+++ b/test/jest.e2e.global_teardown.js
@@ -8,6 +8,7 @@ module.exports = async function () {
   // Guard both globals: if setup failed part-way they may be undefined, and an
   // unguarded close() here would throw and mask the original setup error.
   if (global.__BROWSER_GLOBAL__ !== undefined) await global.__BROWSER_GLOBAL__.close()
+  if (global.__BROWSER_NO_GPU_GLOBAL__ !== undefined) await global.__BROWSER_NO_GPU_GLOBAL__.close()
   if (global.__FIXTURE_SERVER__ !== undefined) {
     await new Promise(resolve => global.__FIXTURE_SERVER__.close(resolve))
   }

--- a/test/puppeteer_environment.js
+++ b/test/puppeteer_environment.js
@@ -25,6 +25,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
     this.global.__BROWSER__ = await puppeteer.connect({
       browserWSEndpoint: wsEndpoint,
     });
+    this.global.__BROWSER_NO_GPU__ = await puppeteer.connect({
+      browserWSEndpoint: fs.readFileSync(path.join(DIR, 'wsEndpointNoGpu'), 'utf8'),
+    });
     this.global.__BASE_URL__ = fs.readFileSync(path.join(DIR, 'baseUrl'), 'utf8');
   }
 

--- a/test/unit/Filter.test.ts
+++ b/test/unit/Filter.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ImageFilter } from '../../src/content/Filter/ImageFilter'
+
+// An image is hidden from the moment it is queued until a verdict comes back, so
+// a request nothing ever answers used to leave it hidden for the life of the
+// page. That is what a wedged TensorFlow.js backend in the offscreen document
+// looks like from here: the message is delivered, the callback never fires.
+// These cover the deadline that reveals the image anyway.
+
+const ANALYSIS_DEADLINE = 60000
+
+// chrome.runtime.sendMessage, with the reply held back until a test releases it.
+const stubRuntime = (): { reply: (response: unknown) => void, sent: () => number } => {
+  let callback: ((response: unknown) => void) | undefined
+  let sent = 0
+
+  const runtime = {
+    lastError: undefined,
+    sendMessage: (_message: unknown, respond: (response: unknown) => void) => {
+      sent++
+      callback = respond
+    }
+  };
+
+  (global as unknown as { chrome: unknown }).chrome = { runtime }
+
+  return { reply: (response: unknown) => callback?.(response), sent: () => sent }
+}
+
+// The same stub, but every send comes back as a runtime error, which is what a
+// torn-down service worker looks like from the content script.
+const stubUnreachableRuntime = (): { sent: () => number } => {
+  let sent = 0
+
+  const runtime = {
+    lastError: { message: 'Could not establish connection' },
+    sendMessage: (_message: unknown, respond: (response: unknown) => void) => {
+      sent++
+      respond(undefined)
+    }
+  };
+
+  (global as unknown as { chrome: unknown }).chrome = { runtime }
+
+  return { sent: () => sent }
+}
+
+const makeImage = (src = 'http://example.com/a.jpg'): HTMLImageElement => {
+  const image = document.createElement('img')
+  image.src = src
+  image.width = 200
+  image.height = 200
+  document.body.appendChild(image)
+
+  return image
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.useRealTimers()
+  document.body.innerHTML = ''
+})
+
+describe('content => Filter => analysis deadline', () => {
+  test('reveals an image the background never answers for', async () => {
+    stubRuntime()
+    const image = makeImage()
+
+    new ImageFilter().analyzeImage(image)
+    expect(image.dataset.nsfwFilterStatus).toBe('processing')
+    expect(image.style.visibility).toBe('hidden')
+
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    expect(image.dataset.nsfwFilterStatus).toBe('sfw')
+    expect(image.style.visibility).toBe('visible')
+  })
+
+  test('keeps the image hidden until the deadline is actually reached', async () => {
+    stubRuntime()
+    const image = makeImage()
+
+    new ImageFilter().analyzeImage(image)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE - 1000)
+
+    expect(image.dataset.nsfwFilterStatus).toBe('processing')
+    expect(image.style.visibility).toBe('hidden')
+  })
+
+  test('does not reveal an image the background answered in time', async () => {
+    const { reply } = stubRuntime()
+    const image = makeImage()
+
+    new ImageFilter().analyzeImage(image)
+    reply({ result: true, url: image.src })
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    expect(image.dataset.nsfwFilterStatus).toBe('nsfw')
+  })
+
+  // A reply that lands after we gave up must not resolve a second time and undo
+  // the reveal, and must not blow up on a queue entry that is already gone.
+  test('ignores a reply that arrives after the deadline', async () => {
+    const { reply } = stubRuntime()
+    const image = makeImage()
+
+    new ImageFilter().analyzeImage(image)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+    reply({ result: true, url: image.src })
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(image.dataset.nsfwFilterStatus).toBe('sfw')
+    expect(image.style.visibility).toBe('visible')
+  })
+
+  // Two <img> elements sharing a src are deduplicated onto one request, so the
+  // deadline has to settle every waiter, not just the first.
+  test('reveals every image waiting on the same url', async () => {
+    stubRuntime()
+    const first = makeImage()
+    const second = makeImage()
+    const filter = new ImageFilter()
+
+    filter.analyzeImage(first)
+    filter.analyzeImage(second)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    expect(first.style.visibility).toBe('visible')
+    expect(second.style.visibility).toBe('visible')
+  })
+
+  // Giving up on an unreachable background worker has to settle every waiter too,
+  // and stop retrying once it has.
+  test('reveals every image when the background worker never comes back', async () => {
+    const { sent } = stubUnreachableRuntime()
+    const first = makeImage()
+    const second = makeImage()
+    const filter = new ImageFilter()
+
+    filter.analyzeImage(first)
+    filter.analyzeImage(second)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    expect(first.style.visibility).toBe('visible')
+    expect(second.style.visibility).toBe('visible')
+    expect(sent()).toBe(6)
+  })
+
+  // A url that timed out can be queued again by a later image. The reply to the
+  // abandoned request must not settle that new request.
+  test('drops a late reply belonging to an abandoned request', async () => {
+    const first = stubRuntime()
+    const image = makeImage()
+    const filter = new ImageFilter()
+
+    filter.analyzeImage(image)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    const second = stubRuntime()
+    const requeued = makeImage()
+    filter.analyzeImage(requeued)
+    first.reply({ result: true, url: requeued.src })
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(requeued.dataset.nsfwFilterStatus).toBe('processing')
+    expect(second.sent()).toBe(1)
+  })
+})

--- a/test/unit/Filter.test.ts
+++ b/test/unit/Filter.test.ts
@@ -3,46 +3,69 @@
  */
 import { ImageFilter } from '../../src/content/Filter/ImageFilter'
 
-// An image is hidden from the moment it is queued until a verdict comes back, so
-// a request nothing ever answers used to leave it hidden for the life of the
-// page. That is what a wedged TensorFlow.js backend in the offscreen document
-// looks like from here: the message is delivered, the callback never fires.
-// These cover the deadline that reveals the image anyway.
+// An image is hidden from the moment it is queued until a verdict comes back, so a
+// request nothing answers used to leave it hidden for the life of the page. That is
+// what a wedged backend looks like from here: the message is delivered, the
+// callback never fires. These cover the deadline that reveals the image anyway.
 
 const ANALYSIS_DEADLINE = 60000
 
+type StubRuntime = { lastError?: { message: string }, sendMessage: unknown }
+
+const installRuntime = (runtime: StubRuntime): void => {
+  (global as unknown as { chrome: unknown }).chrome = { runtime }
+}
+
+// chrome.runtime is a singleton, so lastError is read off whichever stub is
+// installed now, not the one that sent the message.
+const installedRuntime = (): StubRuntime =>
+  (global as unknown as { chrome: { runtime: StubRuntime } }).chrome.runtime
+
 // chrome.runtime.sendMessage, with the reply held back until a test releases it.
-const stubRuntime = (): { reply: (response: unknown) => void, sent: () => number } => {
+const stubRuntime = (): {
+  reply: (response: unknown) => void
+  replyWithError: () => void
+  sent: () => number
+} => {
   let callback: ((response: unknown) => void) | undefined
   let sent = 0
 
-  const runtime = {
+  const runtime: StubRuntime = {
     lastError: undefined,
     sendMessage: (_message: unknown, respond: (response: unknown) => void) => {
       sent++
       callback = respond
     }
-  };
+  }
 
-  (global as unknown as { chrome: unknown }).chrome = { runtime }
+  installRuntime(runtime)
 
-  return { reply: (response: unknown) => callback?.(response), sent: () => sent }
+  return {
+    reply: (response: unknown) => callback?.(response),
+    replyWithError: () => {
+      const installed = installedRuntime()
+      installed.lastError = { message: 'Could not establish connection' }
+      callback?.(undefined)
+      installed.lastError = undefined
+    },
+    sent: () => sent
+  }
 }
 
-// The same stub, but every send comes back as a runtime error, which is what a
-// torn-down service worker looks like from the content script.
+// The same stub, but every send comes back as a runtime error: a torn-down service
+// worker, seen from the content script.
 const stubUnreachableRuntime = (): { sent: () => number } => {
   let sent = 0
 
-  const runtime = {
+  const runtime: StubRuntime = {
     lastError: { message: 'Could not establish connection' },
     sendMessage: (_message: unknown, respond: (response: unknown) => void) => {
       sent++
       respond(undefined)
     }
-  };
+  }
 
-  (global as unknown as { chrome: unknown }).chrome = { runtime }
+  installRuntime(runtime)
 
   return { sent: () => sent }
 }
@@ -104,8 +127,8 @@ describe('content => Filter => analysis deadline', () => {
     expect(image.dataset.nsfwFilterStatus).toBe('nsfw')
   })
 
-  // A reply that lands after we gave up must not resolve a second time and undo
-  // the reveal, and must not blow up on a queue entry that is already gone.
+  // A reply that lands after we gave up must not resolve a second time, and must
+  // not blow up on a queue entry that is already gone.
   test('ignores a reply that arrives after the deadline', async () => {
     const { reply } = stubRuntime()
     const image = makeImage()
@@ -135,8 +158,7 @@ describe('content => Filter => analysis deadline', () => {
     expect(second.style.visibility).toBe('visible')
   })
 
-  // Giving up on an unreachable background worker has to settle every waiter too,
-  // and stop retrying once it has.
+  // Giving up on an unreachable worker settles every waiter and stops retrying.
   test('reveals every image when the background worker never comes back', async () => {
     const { sent } = stubUnreachableRuntime()
     const first = makeImage()
@@ -150,6 +172,41 @@ describe('content => Filter => analysis deadline', () => {
     expect(first.style.visibility).toBe('visible')
     expect(second.style.visibility).toBe('visible')
     expect(sent()).toBe(6)
+  })
+
+  // A sendMessage callback can't be cancelled, so the runtime error for a request
+  // we gave up on still arrives. It must not restart the retry loop.
+  test('does not retry a request that already timed out', async () => {
+    const runtime = stubRuntime()
+    const image = makeImage()
+
+    new ImageFilter().analyzeImage(image)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+    runtime.replyWithError()
+    await jest.advanceTimersByTimeAsync(5000)
+
+    expect(runtime.sent()).toBe(1)
+    expect(image.style.visibility).toBe('visible')
+  })
+
+  // The runtime error for an abandoned request arrives while the same url is queued
+  // again. It must not retry or settle on behalf of the new request.
+  test('drops a late runtime error belonging to an abandoned request', async () => {
+    const first = stubRuntime()
+    const image = makeImage()
+    const filter = new ImageFilter()
+
+    filter.analyzeImage(image)
+    await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
+
+    const second = stubRuntime()
+    const requeued = makeImage()
+    filter.analyzeImage(requeued)
+    first.replyWithError()
+    await jest.advanceTimersByTimeAsync(5000)
+
+    expect(requeued.dataset.nsfwFilterStatus).toBe('processing')
+    expect(second.sent()).toBe(1)
   })
 
   // A url that timed out can be queued again by a later image. The reply to the

--- a/test/unit/PredictionQueue.test.ts
+++ b/test/unit/PredictionQueue.test.ts
@@ -14,9 +14,9 @@ const makeQueue = (): PredictionQueue => {
 }
 
 describe('background => PredictionQueue => onFailure', () => {
-  // A rejected prediction means no verdict came back, not that the image is
-  // safe. Caching it would keep serving "safe" for that url until the cache is
-  // cleared, so a transient model outage would silently unblock images.
+  // A rejected prediction means no verdict, not a safe image. Caching it would
+  // serve "safe" for that url until the cache is cleared, so a transient model
+  // outage would silently unblock images.
   test('does not cache a url the model failed on', () => {
     const queue = makeQueue() as unknown as {
       requestMap: Map<string, unknown>

--- a/test/unit/PredictionQueue.test.ts
+++ b/test/unit/PredictionQueue.test.ts
@@ -1,0 +1,33 @@
+import { PredictionQueue } from '../../src/background/Queue/PredictionQueue'
+import { ILogger } from '../../src/utils/Logger'
+import { IReduxedStorage } from '../../src/background/background'
+import { OffscreenModel } from '../../src/background/OffscreenModel'
+
+const makeQueue = (): PredictionQueue => {
+  const logger = { log: () => {} } as unknown as ILogger
+  const store = {
+    getState: () => ({ statistics: { totalBlocked: 0 } }),
+    dispatch: async () => {}
+  } as unknown as IReduxedStorage
+
+  return new PredictionQueue({} as unknown as OffscreenModel, logger, store)
+}
+
+describe('background => PredictionQueue => onFailure', () => {
+  // A rejected prediction means no verdict came back, not that the image is
+  // safe. Caching it would keep serving "safe" for that url until the cache is
+  // cleared, so a transient model outage would silently unblock images.
+  test('does not cache a url the model failed on', () => {
+    const queue = makeQueue() as unknown as {
+      requestMap: Map<string, unknown>
+      cache: { has: (key: string) => boolean }
+      onFailure: (param: { url: string, error: Error }) => void
+    }
+
+    const url = 'http://example.com/a.jpg'
+    queue.requestMap.set(url, [[{ resolve: () => {}, reject: () => {} }]])
+    queue.onFailure({ url, error: new Error('Model is unavailable') })
+
+    expect(queue.cache.has(url)).toBe(false)
+  })
+})

--- a/test/unit/restartState.test.ts
+++ b/test/unit/restartState.test.ts
@@ -1,0 +1,42 @@
+import { Logger } from '../../src/utils/Logger'
+import { RESTART_KEY, readRestartState, saveRestartState } from '../../src/offscreen/restartState'
+
+// sessionStorage is how the settings the service worker already pushed survive the
+// reload onto WASM, so a record it cannot read costs the user their settings.
+
+const memoryStorage = (): Storage => {
+  const items = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => items.get(key) ?? null,
+    setItem: (key: string, value: string) => { items.set(key, value) },
+    removeItem: (key: string) => { items.delete(key) },
+    clear: () => { items.clear() },
+    key: (index: number) => [...items.keys()][index] ?? null,
+    get length () { return items.size }
+  }
+}
+
+const logger = new Logger()
+
+describe('offscreen => restartState', () => {
+  test('Should round-trip the settings a restart has to carry over', () => {
+    const storage = memoryStorage()
+    const state = { filterStrictness: 42, trainedModel: 'ViT_NSFW_384' as const, logging: true }
+
+    saveRestartState(storage, state)
+
+    expect(readRestartState(storage, logger)).toEqual(state)
+  })
+
+  test('Should report a first start when nothing was saved', () => {
+    expect(readRestartState(memoryStorage(), logger)).toBe(null)
+  })
+
+  test('Should fall back to a first start on a record it cannot parse', () => {
+    const storage = memoryStorage()
+    storage.setItem(RESTART_KEY, 'not json')
+
+    expect(readRestartState(storage, logger)).toBe(null)
+  })
+})


### PR DESCRIPTION
#### Changes

On a machine without a usable GPU, the whole page could stay blank. The offscreen document brings TensorFlow.js up on WebGL, and when the model warm-up timed out there, the old code called `setBackend('wasm')` on the live engine. `withTimeout` doesn't cancel the GPU work it gave up on, so the engine waited on it forever, and because backend bring-up runs on the serialised op chain every queued image was stuck behind it. Images are hidden from the moment they're queued and revealed only when a verdict comes back, so they were hidden for the life of the page. Reproduced locally with a 330s run where every image was still `data-nsfw-filter-status="processing"` and `visibility: hidden`.

Three changes:

- The content script now owns a 60s deadline per URL. If no verdict arrives, the image is revealed instead of staying hidden. Showing an unclassified image is a bad outcome; a permanently blank page is a worse one, and it's how the filter already degrades when the background worker is down. A reply that arrives after we gave up is dropped rather than resolving twice, matched by request rather than by URL so it can't settle a later request for the same image, and giving up also stops the reconnect timer. The existing "background worker is down" path had the same shape of bug: it only resolved the first waiter, so duplicate `<img>` elements sharing a src stayed hidden.
- The offscreen document no longer switches backends in place, on any WebGL failure. It writes what it needs to `sessionStorage` and reloads itself, so WASM comes up in a clean realm with no orphaned GPU work, and the recorded restart stops a bad GPU turning into a reload loop. The service worker doesn't re-push settings to a document it didn't start, so the strictness, model, and logging state ride along in that same record. Alongside that, `setBackend()` returns a boolean that was being ignored, the `tf.ready()` after it was redundant, and `currentBackend` was set before the backend was known to be live.
- `PredictionQueue.onFailure` no longer caches the URL as safe. A failure means no verdict came back, usually the model being unavailable, so caching `false` kept serving "safe" for that URL for the rest of the session.

#### Testing

- Unit tests for the deadline, the reconnect give-up, and stale replies (`test/unit/Filter.test.ts`), and for the failure cache (`test/unit/PredictionQueue.test.ts`). All six fail against `master` and pass here.
- A new e2e suite (`test/e2e/noGpuFallback.test.js`) runs the extension in a second browser launched with GL off, which is the real no-GPU path. It asserts the page settles inside 40s, below the content script's deadline, so a page that only recovered by failing open still fails the test, and it reads the offscreen document's restart record to prove it got to WASM by restarting once rather than by switching in place. The harness launches that browser in `globalSetup` because test files can't launch Puppeteer themselves.
- Also verified in a real browser with a forced WebGL warm-up failure, the case the flags can't produce: the offscreen document reloaded, came back up on WASM with the settings intact, and classified normally.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed image analyses no longer produce cached “safe” results.
  - Images are revealed after a timeout when analysis cannot complete.
  - Late or stale analysis responses no longer affect newer requests.
  - Recovery is improved when background processing or reconnection attempts fail.

- **Reliability**
  - Improved WebGL initialization and automatic fallback to WASM when GPU support is unavailable.
  - Processing can restart more reliably while preserving settings.

- **Tests**
  - Added coverage for timeout handling, recovery, stale responses, restart persistence, and no-GPU operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->