### PR TITLE
feat: filter CSS background images (#46)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "antd": "6.5.0",
         "lucide-react": "1.21.0",
         "nsfwjs": "4.3.0",
+        "postcss-value-parser": "4.2.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-redux": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "antd": "6.5.0",
     "lucide-react": "1.21.0",
     "nsfwjs": "4.3.0",
+    "postcss-value-parser": "4.2.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-redux": "9.3.0",

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -2,9 +2,8 @@
 // https://stackoverflow.com/a/39332340/10432429
 
 // @TODO Canvas and SVG
-// @TODO Lazy loading for div.style.background-image?
-// @TODO <div> and <a>
 
+import { IBackgroundImageFilter } from '../Filter/BackgroundImageFilter'
 import { IImageFilter } from '../Filter/ImageFilter'
 import { IVideoFilter } from '../Filter/VideoFilter'
 
@@ -17,11 +16,17 @@ export class DOMWatcher implements IDOMWatcher {
   private readonly observer: MutationObserver
   private readonly imageFilter: IImageFilter
   private readonly videoFilter: IVideoFilter
+  private readonly backgroundFilter: IBackgroundImageFilter
   private watching: boolean
 
-  constructor (imageFilter: IImageFilter, videoFilter: IVideoFilter) {
+  constructor (
+    imageFilter: IImageFilter,
+    videoFilter: IVideoFilter,
+    backgroundFilter: IBackgroundImageFilter
+  ) {
     this.imageFilter = imageFilter
     this.videoFilter = videoFilter
+    this.backgroundFilter = backgroundFilter
     this.observer = new MutationObserver(this.callback.bind(this))
     this.watching = false
   }
@@ -37,6 +42,8 @@ export class DOMWatcher implements IDOMWatcher {
     // DOM so anything parsed before the (async) store resolved is still hidden
     // and classified instead of missed.
     this.findAndCheckAllMedia(document.documentElement)
+    this.backgroundFilter.observe(document.documentElement)
+    this.watchStyleSheets(document.documentElement)
   }
 
   // Live pause / allow-list: stop reacting to the page so no new image gets
@@ -50,12 +57,48 @@ export class DOMWatcher implements IDOMWatcher {
   private callback (mutationsList: MutationRecord[]): void {
     for (let i = 0; i < mutationsList.length; i++) {
       const mutation = mutationsList[i]
-      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+      if (mutation.type === 'childList') {
+        // A removed subtree has to give up its override and its pending request,
+        // and a stale registration would keep the element alive with the page.
+        mutation.removedNodes.forEach(node => {
+          if (node instanceof Element) this.backgroundFilter.release(node)
+        })
+        if (mutation.addedNodes.length === 0) continue
+
         this.findAndCheckAllMedia(mutation.target as Element)
+        // Backgrounds are registered per added subtree rather than by re-walking
+        // the mutation target: a feed appending rows would otherwise re-walk the
+        // whole feed on every row.
+        mutation.addedNodes.forEach(node => {
+          if (!(node instanceof Element)) return
+          this.backgroundFilter.observe(node)
+          this.watchStyleSheets(node)
+        })
       } else if (mutation.type === 'attributes') {
         this.checkAttributeMutation(mutation)
       }
     }
+  }
+
+  // A stylesheet can give an element on screen a background without touching an
+  // attribute or an intersection, so its arrival is what prompts the recheck.
+  private watchStyleSheets (root: Element): void {
+    const sheets = [...root.querySelectorAll('link[rel~="stylesheet"], style')]
+    if (root.matches('link[rel~="stylesheet"], style')) sheets.push(root)
+    if (sheets.length === 0) return
+
+    this.backgroundFilter.recheckVisible()
+    sheets.forEach(sheet => {
+      if (sheet.nodeName === 'LINK') {
+        sheet.addEventListener('load', () => this.backgroundFilter.recheckVisible())
+        return
+      }
+
+      // A <style> is often inserted empty and filled in afterwards, and its rules
+      // are text: nothing about that reaches the document-level observer.
+      new MutationObserver(() => this.backgroundFilter.recheckVisible())
+        .observe(sheet, { characterData: true, childList: true, subtree: true })
+    })
   }
 
   private findAndCheckAllMedia (element: Element): void {
@@ -71,7 +114,18 @@ export class DOMWatcher implements IDOMWatcher {
   }
 
   private checkAttributeMutation (mutation: MutationRecord): void {
-    const node = mutation.target as Element
+    const node = mutation.target
+    if (!(node instanceof HTMLElement)) return
+
+    // A class change can bring in a rule carrying a background image; a style
+    // change can set one directly. An <img> can carry one too, so this runs for
+    // images as well as for everything else.
+    if (mutation.attributeName === 'style') {
+      this.backgroundFilter.checkStyleMutation(node)
+    } else if (mutation.attributeName === 'class') {
+      this.backgroundFilter.checkElement(node)
+    }
+
     if (node.nodeName === 'IMG') {
       const image = node as HTMLImageElement
       // A style change is the page overwriting our effect (see checkStyleMutation),
@@ -110,7 +164,7 @@ export class DOMWatcher implements IDOMWatcher {
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ['src', 'style', 'poster']
+      attributeFilter: ['src', 'style', 'poster', 'class']
     }
   }
 }

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -114,14 +114,14 @@ export class DOMWatcher implements IDOMWatcher {
       if (this.registered.has(sheet)) return
       this.registered.add(sheet)
 
-      if (sheet.nodeName === 'LINK') {
-        sheet.addEventListener(
-          'load',
-          () => this.backgroundFilter.recheckVisible(),
-          { signal: this.sheetLoads.signal }
-        )
-        return
-      }
+      // A <style> fires load once its @import rules have finished, which is the
+      // only signal that those rules exist.
+      sheet.addEventListener(
+        'load',
+        () => this.backgroundFilter.recheckVisible(),
+        { signal: this.sheetLoads.signal }
+      )
+      if (sheet.nodeName === 'LINK') return
 
       // A <style> is often inserted empty and filled in afterwards, and its rules
       // are text: nothing about that reaches the document-level observer.
@@ -195,7 +195,9 @@ export class DOMWatcher implements IDOMWatcher {
 
   // Backgrounds selected through other attributes, through CSSOM insertRule, or
   // through adopted stylesheets and shadow roots are not covered: watching every
-  // attribute would re-read the visible set on any page that animates one.
+  // attribute would re-read the visible set on any page that animates one. Nor
+  // are selectors that reach outside the changed element's parent, :has() above
+  // all, for the same reason: a mutation there rechecks that subtree only.
   private static getConfig (): MutationObserverInit {
     return {
       characterData: false,

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -19,6 +19,9 @@ export class DOMWatcher implements IDOMWatcher {
   private readonly imageFilter: IImageFilter
   private readonly videoFilter: IVideoFilter
   private readonly backgroundFilter: IBackgroundImageFilter
+  private sheetObservers: MutationObserver[]
+  private sheetLoads: AbortController
+  private registered: WeakSet<Element>
   private watching: boolean
 
   constructor (
@@ -30,6 +33,9 @@ export class DOMWatcher implements IDOMWatcher {
     this.videoFilter = videoFilter
     this.backgroundFilter = backgroundFilter
     this.observer = new MutationObserver(this.callback.bind(this))
+    this.sheetObservers = []
+    this.sheetLoads = new AbortController()
+    this.registered = new WeakSet()
     this.watching = false
   }
 
@@ -54,6 +60,13 @@ export class DOMWatcher implements IDOMWatcher {
     if (!this.watching) return
     this.watching = false
     this.observer.disconnect()
+    // Every stylesheet gets its own observer, so a stop that left them running
+    // would keep both the callbacks and the removed <style> elements alive.
+    this.sheetObservers.forEach(observer => observer.disconnect())
+    this.sheetObservers = []
+    this.sheetLoads.abort()
+    this.sheetLoads = new AbortController()
+    this.registered = new WeakSet()
   }
 
   private callback (mutationsList: MutationRecord[]): void {
@@ -98,20 +111,29 @@ export class DOMWatcher implements IDOMWatcher {
 
     this.backgroundFilter.recheckVisible()
     sheets.forEach(sheet => {
+      if (this.registered.has(sheet)) return
+      this.registered.add(sheet)
+
       if (sheet.nodeName === 'LINK') {
-        sheet.addEventListener('load', () => this.backgroundFilter.recheckVisible())
+        sheet.addEventListener(
+          'load',
+          () => this.backgroundFilter.recheckVisible(),
+          { signal: this.sheetLoads.signal }
+        )
         return
       }
 
       // A <style> is often inserted empty and filled in afterwards, and its rules
       // are text: nothing about that reaches the document-level observer.
-      new MutationObserver(() => this.backgroundFilter.recheckVisible())
-        .observe(sheet, { characterData: true, childList: true, subtree: true })
+      const observer = new MutationObserver(() => this.backgroundFilter.recheckVisible())
+      observer.observe(sheet, { characterData: true, childList: true, subtree: true })
+      this.sheetObservers.push(observer)
     })
   }
 
+  // A sheet is usually removed with the container it sits in, not on its own.
   private isStyleSheet (element: Element): boolean {
-    return element.matches(STYLE_SHEET)
+    return element.matches(STYLE_SHEET) || element.querySelector(STYLE_SHEET) !== null
   }
 
   private findAndCheckAllMedia (element: Element): void {
@@ -130,12 +152,12 @@ export class DOMWatcher implements IDOMWatcher {
     const node = mutation.target
     if (!(node instanceof HTMLElement)) return
 
-    // A class change can bring in a rule carrying a background image; a style
-    // change can set one directly. An <img> can carry one too, so this runs for
-    // images as well as for everything else.
+    // A class, id or hidden change can bring in a rule carrying a background
+    // image; a style change can set one directly. An <img> can carry one too, so
+    // this runs for images as well as for everything else.
     if (mutation.attributeName === 'style') {
       this.backgroundFilter.checkStyleMutation(node)
-    } else if (mutation.attributeName === 'class') {
+    } else if (mutation.attributeName !== 'src' && mutation.attributeName !== 'poster') {
       this.backgroundFilter.checkElement(node)
     }
 

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -19,7 +19,7 @@ export class DOMWatcher implements IDOMWatcher {
   private readonly imageFilter: IImageFilter
   private readonly videoFilter: IVideoFilter
   private readonly backgroundFilter: IBackgroundImageFilter
-  private sheetObservers: MutationObserver[]
+  private sheetObservers: Map<Element, MutationObserver>
   private sheetLoads: AbortController
   private registered: WeakSet<Element>
   private watching: boolean
@@ -33,7 +33,7 @@ export class DOMWatcher implements IDOMWatcher {
     this.videoFilter = videoFilter
     this.backgroundFilter = backgroundFilter
     this.observer = new MutationObserver(this.callback.bind(this))
-    this.sheetObservers = []
+    this.sheetObservers = new Map()
     this.sheetLoads = new AbortController()
     this.registered = new WeakSet()
     this.watching = false
@@ -63,7 +63,7 @@ export class DOMWatcher implements IDOMWatcher {
     // Every stylesheet gets its own observer, so a stop that left them running
     // would keep both the callbacks and the removed <style> elements alive.
     this.sheetObservers.forEach(observer => observer.disconnect())
-    this.sheetObservers = []
+    this.sheetObservers.clear()
     this.sheetLoads.abort()
     this.sheetLoads = new AbortController()
     this.registered = new WeakSet()
@@ -80,7 +80,9 @@ export class DOMWatcher implements IDOMWatcher {
           this.backgroundFilter.release(node)
           // Dropping a sheet takes its rules with it, which can expose a
           // background an earlier sheet was overriding.
-          if (this.isStyleSheet(node)) this.backgroundFilter.recheckVisible()
+          if (!this.isStyleSheet(node)) return
+          this.backgroundFilter.recheckVisible()
+          this.dropStyleSheets(node)
         })
         // A sibling arriving or leaving decides `+`, `~` and `:first-child`, so the
         // element being changed is dirty even when nothing about it moved.
@@ -127,7 +129,20 @@ export class DOMWatcher implements IDOMWatcher {
       // are text: nothing about that reaches the document-level observer.
       const observer = new MutationObserver(() => this.backgroundFilter.recheckVisible())
       observer.observe(sheet, { characterData: true, childList: true, subtree: true })
-      this.sheetObservers.push(observer)
+      this.sheetObservers.set(sheet, observer)
+    })
+  }
+
+  // A page that mounts and unmounts styles for every render would otherwise leave
+  // an observer, and the detached <style> it holds, behind on each one.
+  private dropStyleSheets (root: Element): void {
+    const sheets = [...root.querySelectorAll(STYLE_SHEET)]
+    if (root.matches(STYLE_SHEET)) sheets.push(root)
+
+    sheets.forEach(sheet => {
+      this.sheetObservers.get(sheet)?.disconnect()
+      this.sheetObservers.delete(sheet)
+      this.registered.delete(sheet)
     })
   }
 

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -7,6 +7,8 @@ import { IBackgroundImageFilter } from '../Filter/BackgroundImageFilter'
 import { IImageFilter } from '../Filter/ImageFilter'
 import { IVideoFilter } from '../Filter/VideoFilter'
 
+const STYLE_SHEET = 'link[rel~="stylesheet"], style'
+
 export type IDOMWatcher = {
   watch: () => void
   unwatch: () => void
@@ -61,8 +63,15 @@ export class DOMWatcher implements IDOMWatcher {
         // A removed subtree has to give up its override and its pending request,
         // and a stale registration would keep the element alive with the page.
         mutation.removedNodes.forEach(node => {
-          if (node instanceof Element) this.backgroundFilter.release(node)
+          if (!(node instanceof Element)) return
+          this.backgroundFilter.release(node)
+          // Dropping a sheet takes its rules with it, which can expose a
+          // background an earlier sheet was overriding.
+          if (this.isStyleSheet(node)) this.backgroundFilter.recheckVisible()
         })
+        // A sibling arriving or leaving decides `+`, `~` and `:first-child`, so the
+        // element being changed is dirty even when nothing about it moved.
+        if (mutation.target instanceof HTMLElement) this.backgroundFilter.checkElement(mutation.target)
         if (mutation.addedNodes.length === 0) continue
 
         this.findAndCheckAllMedia(mutation.target as Element)
@@ -83,8 +92,8 @@ export class DOMWatcher implements IDOMWatcher {
   // A stylesheet can give an element on screen a background without touching an
   // attribute or an intersection, so its arrival is what prompts the recheck.
   private watchStyleSheets (root: Element): void {
-    const sheets = [...root.querySelectorAll('link[rel~="stylesheet"], style')]
-    if (root.matches('link[rel~="stylesheet"], style')) sheets.push(root)
+    const sheets = [...root.querySelectorAll(STYLE_SHEET)]
+    if (root.matches(STYLE_SHEET)) sheets.push(root)
     if (sheets.length === 0) return
 
     this.backgroundFilter.recheckVisible()
@@ -99,6 +108,10 @@ export class DOMWatcher implements IDOMWatcher {
       new MutationObserver(() => this.backgroundFilter.recheckVisible())
         .observe(sheet, { characterData: true, childList: true, subtree: true })
     })
+  }
+
+  private isStyleSheet (element: Element): boolean {
+    return element.matches(STYLE_SHEET)
   }
 
   private findAndCheckAllMedia (element: Element): void {
@@ -158,13 +171,16 @@ export class DOMWatcher implements IDOMWatcher {
     this.videoFilter.analyzeVideo(video, false)
   }
 
+  // Backgrounds selected through other attributes, through CSSOM insertRule, or
+  // through adopted stylesheets and shadow roots are not covered: watching every
+  // attribute would re-read the visible set on any page that animates one.
   private static getConfig (): MutationObserverInit {
     return {
       characterData: false,
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ['src', 'style', 'poster', 'class']
+      attributeFilter: ['src', 'style', 'poster', 'class', 'id', 'hidden']
     }
   }
 }

--- a/src/content/Filter/BackgroundImageFilter.ts
+++ b/src/content/Filter/BackgroundImageFilter.ts
@@ -26,7 +26,7 @@ type BackgroundState = {
   pending: boolean
   // The inline declaration as the page left it, so the cascade comes back exactly
   // as it was rather than as a serialized computed value.
-  inline: { value: string, priority: string } | null
+  inline: { value: string, priority: string, shorthand: { value: string, priority: string } | null } | null
 }
 
 const MIN_ELEMENT_SIZE = 41
@@ -315,10 +315,17 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   // visibility on the element would take its text and children with it.
   private hide (element: HTMLElement, state: BackgroundState): void {
     if (state.inline === null) {
-      state.inline = {
-        value: element.style.getPropertyValue('background-image'),
-        priority: element.style.getPropertyPriority('background-image')
-      }
+      const value = element.style.getPropertyValue('background-image')
+      // `background: var(--photo)` has no readable longhand, and the override
+      // takes the shorthand with it, so the shorthand is what has to come back.
+      const shorthand = value === '' && element.style.getPropertyValue('background') !== ''
+        ? {
+            value: element.style.getPropertyValue('background'),
+            priority: element.style.getPropertyPriority('background')
+          }
+        : null
+
+      state.inline = { value, priority: element.style.getPropertyPriority('background-image'), shorthand }
     }
 
     this.write(element, () => element.style.setProperty('background-image', 'none', 'important'))
@@ -333,19 +340,16 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
     const state = this.states.get(element)
     if (state?.inline == null) return
 
-    const { value, priority } = state.inline
+    const { value, priority, shorthand } = state.inline
     state.inline = null
     // The page overwrote the whole declaration; whatever it wants there now is
     // newer than what we saved.
     if (!this.overridden(element)) return
 
     this.write(element, () => {
-      if (value === '') {
-        element.style.removeProperty('background-image')
-        return
-      }
-
-      element.style.setProperty('background-image', value, priority)
+      element.style.removeProperty('background-image')
+      if (shorthand !== null) element.style.setProperty('background', shorthand.value, shorthand.priority)
+      else if (value !== '') element.style.setProperty('background-image', value, priority)
     })
   }
 

--- a/src/content/Filter/BackgroundImageFilter.ts
+++ b/src/content/Filter/BackgroundImageFilter.ts
@@ -1,0 +1,364 @@
+import { PredictionRequest } from '../../utils/messages'
+
+import { backgroundImageUrls } from './backgroundImageValue'
+import { Filter } from './Filter'
+
+export type IBackgroundImageFilter = {
+  observe: (root: Element) => void
+  release: (root: Element) => void
+  checkElement: (element: HTMLElement) => void
+  checkStyleMutation: (element: HTMLElement) => void
+  recheckVisible: () => void
+  applyEffectToBlocked: () => void
+  revealAll: () => void
+  start: () => void
+  stop: () => void
+}
+
+type BackgroundState = {
+  // Bumped whenever the element's background stack changes. A verdict carrying an
+  // older generation is for a background this element no longer shows, which is
+  // what a recycled list row looks like from here.
+  generation: number
+  key: string
+  // A request is out for this key. Without it, a verdict dropped while filtering
+  // was paused would leave the element on `processing` with nothing to settle it.
+  pending: boolean
+  // The inline declaration as the page left it, so the cascade comes back exactly
+  // as it was rather than as a serialized computed value.
+  inline: { value: string, priority: string } | null
+}
+
+const MIN_ELEMENT_SIZE = 41
+const OFFSCREEN_MARGIN = '300px'
+// Past this many dirty roots, testing every visible element against each of them
+// costs more than simply re-reading the visible set.
+const DIRTY_ROOT_LIMIT = 8
+// A drag fires resize continuously; one recheck per quarter second is enough to
+// catch a breakpoint being crossed.
+const RESIZE_INTERVAL = 250
+// Elements that never paint a background, so walking into them is wasted work.
+const SKIPPED = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'TITLE', 'HEAD', 'TEMPLATE', 'NOSCRIPT', 'BR'])
+
+export class BackgroundImageFilter extends Filter implements IBackgroundImageFilter {
+  private readonly states: WeakMap<HTMLElement, BackgroundState>
+  private readonly visible: Set<HTMLElement>
+  private readonly writes: WeakMap<HTMLElement, number>
+  private readonly dirty: Set<HTMLElement>
+  private readonly viewport: IntersectionObserver
+  private allDirty: boolean
+  private scheduled: boolean
+  private resizeTimer: ReturnType<typeof setTimeout> | undefined
+  private active: boolean
+
+  constructor () {
+    super()
+    this.states = new WeakMap()
+    this.visible = new Set()
+    this.writes = new WeakMap()
+    this.dirty = new Set()
+    this.allDirty = false
+    this.scheduled = false
+    this.resizeTimer = undefined
+    this.active = true
+    this.viewport = new IntersectionObserver(
+      this.onIntersection.bind(this),
+      { rootMargin: OFFSCREEN_MARGIN }
+    )
+    // A media query can swap a background under an element that never moves and
+    // never changes an attribute, so a resize is the only sign it happened.
+    window.addEventListener('resize', () => {
+      if (this.resizeTimer !== undefined) return
+      this.resizeTimer = setTimeout(() => {
+        this.resizeTimer = undefined
+        this.recheckVisible()
+      }, RESIZE_INTERVAL)
+    })
+  }
+
+  // Whether an element has a background is only knowable from computed style, and
+  // asking every element on load costs a full style resolution. Registration is
+  // cheap; the question is asked when the element comes near the viewport.
+  public observe (root: Element): void {
+    if (!this.active) return
+
+    this.walk(root, element => {
+      this.viewport.observe(element)
+      // Observing an element again produces no notification, so an element we have
+      // already judged and that moved here needs an explicit re-read: its new
+      // parent can select a different background.
+      if (this.states.has(element)) this.markDirty(element)
+    })
+  }
+
+  // A removed subtree keeps its override and its pending request otherwise, which
+  // leaves the background missing for good if the element comes back.
+  public release (root: Element): void {
+    this.walk(root, element => {
+      if (element.isConnected) {
+        // Moved rather than removed: keep it hidden and force a fresh verdict. Its
+        // registration still stands, and an element that stays on screen through
+        // the move gets no new notification, so it keeps its place in `visible`.
+        const state = this.states.get(element)
+        if (state !== undefined) state.key = ''
+        this.markDirty(element)
+        return
+      }
+
+      this.visible.delete(element)
+      this.dirty.delete(element)
+      this.viewport.unobserve(element)
+      if (!this.states.has(element)) return
+      this.restore(element)
+      this.states.delete(element)
+      delete element.dataset.nsfwFilterBackgroundStatus
+    })
+  }
+
+  // A class change can swap the background of the element itself or of anything
+  // under it, and a rule that now matches produces no new intersection.
+  public checkElement (element: HTMLElement): void {
+    this.markDirty(element)
+  }
+
+  // Some sites rewrite inline styles on every render, which takes our override
+  // with them. Each of our own writes accounts for exactly one mutation, so they
+  // are counted off one by one: an intact override proves nothing, and a page that
+  // writes in reaction to ours must not be swallowed along with it.
+  public checkStyleMutation (element: HTMLElement): void {
+    const ours = this.writes.get(element) ?? 0
+    if (ours > 0) {
+      this.writes.set(element, ours - 1)
+      return
+    }
+
+    this.checkElement(element)
+  }
+
+  // A stylesheet arriving late changes no attribute and triggers no intersection,
+  // so nothing else would ask about the backgrounds it brings.
+  public recheckVisible (): void {
+    if (!this.active) return
+    this.allDirty = true
+    this.schedule()
+  }
+
+  // A live effect change doesn't alter a verdict. Backgrounds are removed rather
+  // than blurred whatever the effect is, so there is nothing to re-render; the
+  // hook exists so content.ts can treat both filters the same.
+  public applyEffectToBlocked (): void {}
+
+  public revealAll (): void {
+    this.filtered().forEach(element => {
+      this.restore(element)
+      this.states.delete(element)
+      delete element.dataset.nsfwFilterBackgroundStatus
+    })
+  }
+
+  // Resuming produces no new intersection for targets already registered, so what
+  // is on screen has to be re-read here or it stays revealed.
+  public start (): void {
+    this.active = true
+    this.recheckVisible()
+  }
+
+  // Live pause or allow-list. Restoring what we removed is revealAll's job.
+  public stop (): void {
+    this.active = false
+    this.dirty.clear()
+    this.allDirty = false
+  }
+
+  private walk (root: Element, visit: (element: HTMLElement) => void): void {
+    if (root instanceof HTMLElement && !SKIPPED.has(root.nodeName)) visit(root)
+    if (SKIPPED.has(root.nodeName)) return
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+      acceptNode: node => SKIPPED.has(node.nodeName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+    })
+
+    while (walker.nextNode() !== null) {
+      const element = walker.currentNode
+      if (element instanceof HTMLElement) visit(element)
+    }
+  }
+
+  private markDirty (element: HTMLElement): void {
+    if (!this.active) return
+    this.dirty.add(element)
+    this.schedule()
+  }
+
+  // Mutations arrive in bursts, and one ancestor change can dirty every card under
+  // it. Reading style per mutation would interleave reads and writes across the
+  // whole burst; one pass afterwards reads each element once.
+  private schedule (): void {
+    if (this.scheduled) return
+    this.scheduled = true
+    setTimeout(() => {
+      this.scheduled = false
+      this.flush()
+    }, 0)
+  }
+
+  private flush (): void {
+    const roots = [...this.dirty]
+    const all = this.allDirty
+    this.dirty.clear()
+    this.allDirty = false
+    if (!this.active) return
+
+    if (all || roots.length > DIRTY_ROOT_LIMIT) {
+      for (const candidate of [...this.visible]) this.analyze(candidate)
+      return
+    }
+
+    const done = new Set<HTMLElement>()
+    for (const root of roots) {
+      if (!this.visible.has(root) && root.dataset.nsfwFilterBackgroundStatus === undefined) continue
+      done.add(root)
+      this.analyze(root)
+    }
+
+    for (const candidate of [...this.visible]) {
+      if (done.has(candidate)) continue
+      // Sibling combinators put the affected element beside the changed one, not
+      // under it, so the parent is the smallest subtree that holds both.
+      if (roots.some(root => (root.parentElement ?? root).contains(candidate))) this.analyze(candidate)
+    }
+  }
+
+  private onIntersection (entries: IntersectionObserverEntry[]): void {
+    for (const entry of entries) {
+      const element = entry.target as HTMLElement
+      if (!entry.isIntersecting) {
+        this.visible.delete(element)
+        if (!element.isConnected) this.release(element)
+        continue
+      }
+
+      this.visible.add(element)
+      this.analyze(element)
+    }
+  }
+
+  private analyze (element: HTMLElement): void {
+    if (!this.active || !element.isConnected) return
+    // Icons, sprites and spacers: too small to be worth a round trip.
+    const { width, height } = element.getBoundingClientRect()
+    if (width <= MIN_ELEMENT_SIZE || height <= MIN_ELEMENT_SIZE) return
+
+    const state = this.states.get(element)
+    // Our own override masks the author's value, so the page's current background
+    // has to be read with it lifted. Both writes land in this task, before paint.
+    if (state !== undefined) this.restore(element)
+
+    const urls = backgroundImageUrls(getComputedStyle(element).backgroundImage)
+    const key = urls.join(' ')
+    if (urls.length === 0) {
+      if (state !== undefined) {
+        this.states.delete(element)
+        delete element.dataset.nsfwFilterBackgroundStatus
+      }
+      return
+    }
+
+    const status = element.dataset.nsfwFilterBackgroundStatus
+    if (state !== undefined && state.key === key && status !== undefined && (status !== 'processing' || state.pending)) {
+      // Same background as the verdict we already hold, or as the one still in
+      // flight; put the effect back if it was a block, since restore() lifted it.
+      if (status !== 'sfw') this.hide(element, state)
+      return
+    }
+
+    const generation = (state?.generation ?? 0) + 1
+    const next: BackgroundState = { generation, key, pending: true, inline: null }
+    this.states.set(element, next)
+    element.dataset.nsfwFilterBackgroundStatus = 'processing'
+    this.hide(element, next)
+
+    void this.classify(element, next, urls)
+  }
+
+  // One unsafe layer condemns the stack: the layers are positioned against each
+  // other, and dropping only one leaves the rest misaligned over a gap.
+  private async classify (element: HTMLElement, state: BackgroundState, urls: string[]): Promise<void> {
+    let blocked = false
+
+    for (const url of urls) {
+      try {
+        const { result } = await this.requestToAnalyzeImage(new PredictionRequest(url))
+        if (result) {
+          blocked = true
+          break
+        }
+      } catch {
+        // Fail open: an unanswered background is the page's own, not ours to keep.
+      }
+    }
+
+    state.pending = false
+    if (this.states.get(element) !== state || !this.active) return
+
+    if (blocked) {
+      this.blockedItems++
+      element.dataset.nsfwFilterBackgroundStatus = 'nsfw'
+      return
+    }
+
+    element.dataset.nsfwFilterBackgroundStatus = 'sfw'
+    this.restore(element)
+  }
+
+  // Removing the image is the only effect that leaves the element alone: blur or
+  // visibility on the element would take its text and children with it.
+  private hide (element: HTMLElement, state: BackgroundState): void {
+    if (state.inline === null) {
+      state.inline = {
+        value: element.style.getPropertyValue('background-image'),
+        priority: element.style.getPropertyPriority('background-image')
+      }
+    }
+
+    this.write(element, () => element.style.setProperty('background-image', 'none', 'important'))
+  }
+
+  private overridden (element: HTMLElement): boolean {
+    return element.style.getPropertyValue('background-image') === 'none' &&
+      element.style.getPropertyPriority('background-image') === 'important'
+  }
+
+  private restore (element: HTMLElement): void {
+    const state = this.states.get(element)
+    if (state?.inline == null) return
+
+    const { value, priority } = state.inline
+    state.inline = null
+    // The page overwrote the whole declaration; whatever it wants there now is
+    // newer than what we saved.
+    if (!this.overridden(element)) return
+
+    this.write(element, () => {
+      if (value === '') {
+        element.style.removeProperty('background-image')
+        return
+      }
+
+      element.style.setProperty('background-image', value, priority)
+    })
+  }
+
+  // The mutations for a write are delivered to the observer as a microtask, so the
+  // credit has to outlive this task and be dropped behind that delivery: a write
+  // made while nothing is observing would otherwise eat a later page mutation.
+  private write (element: HTMLElement, apply: () => void): void {
+    this.writes.set(element, (this.writes.get(element) ?? 0) + 1)
+    apply()
+    queueMicrotask(() => this.writes.delete(element))
+  }
+
+  private filtered (): HTMLElement[] {
+    return [...document.querySelectorAll<HTMLElement>('[data-nsfw-filter-background-status]')]
+  }
+}

--- a/src/content/Filter/BackgroundImageFilter.ts
+++ b/src/content/Filter/BackgroundImageFilter.ts
@@ -26,7 +26,14 @@ type BackgroundState = {
   pending: boolean
   // The inline declaration as the page left it, so the cascade comes back exactly
   // as it was rather than as a serialized computed value.
-  inline: { value: string, priority: string, shorthand: { value: string, priority: string } | null } | null
+  inline: {
+    value: string
+    priority: string
+    shorthand: { value: string, priority: string } | null
+    // Whether the page had a style attribute at all: `.card[style]` rules make an
+    // empty one we left behind a background of its own.
+    attribute: boolean
+  } | null
 }
 
 const MIN_ELEMENT_SIZE = 41
@@ -245,9 +252,12 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
 
   private analyze (element: HTMLElement): void {
     if (!this.active || !element.isConnected) return
-    // Icons, sprites and spacers: too small to be worth a round trip.
+    // Icons, sprites and spacers: too small to be worth a round trip. The root
+    // and the body are exempt: their background paints the whole canvas whatever
+    // box they happen to have.
     const { width, height } = element.getBoundingClientRect()
-    if (width <= MIN_ELEMENT_SIZE || height <= MIN_ELEMENT_SIZE) return
+    const canvas = element === document.body || element === document.documentElement
+    if (!canvas && (width <= MIN_ELEMENT_SIZE || height <= MIN_ELEMENT_SIZE)) return
 
     const state = this.states.get(element)
     // Our own override masks the author's value, so the page's current background
@@ -325,10 +335,18 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
           }
         : null
 
-      state.inline = { value, priority: element.style.getPropertyPriority('background-image'), shorthand }
+      state.inline = {
+        value,
+        priority: element.style.getPropertyPriority('background-image'),
+        shorthand,
+        attribute: element.hasAttribute('style')
+      }
     }
 
-    this.write(element, () => element.style.setProperty('background-image', 'none', 'important'))
+    this.write(element, () => {
+      element.style.setProperty('background-image', 'none', 'important')
+      return 1
+    })
   }
 
   private overridden (element: HTMLElement): boolean {
@@ -340,7 +358,7 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
     const state = this.states.get(element)
     if (state?.inline == null) return
 
-    const { value, priority, shorthand } = state.inline
+    const { value, priority, shorthand, attribute } = state.inline
     state.inline = null
     // The page overwrote the whole declaration; whatever it wants there now is
     // newer than what we saved.
@@ -348,17 +366,33 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
 
     this.write(element, () => {
       element.style.removeProperty('background-image')
-      if (shorthand !== null) element.style.setProperty('background', shorthand.value, shorthand.priority)
-      else if (value !== '') element.style.setProperty('background-image', value, priority)
+      let mutations = 1
+
+      if (shorthand !== null) {
+        element.style.setProperty('background', shorthand.value, shorthand.priority)
+        mutations++
+      } else if (value !== '') {
+        element.style.setProperty('background-image', value, priority)
+        mutations++
+      }
+
+      if (!attribute && element.style.length === 0) {
+        element.removeAttribute('style')
+        mutations++
+      }
+
+      return mutations
     })
   }
 
   // The mutations for a write are delivered to the observer as a microtask, so the
   // credit has to outlive this task and be dropped behind that delivery: a write
   // made while nothing is observing would otherwise eat a later page mutation.
-  private write (element: HTMLElement, apply: () => void): void {
-    this.writes.set(element, (this.writes.get(element) ?? 0) + 1)
-    apply()
+  // One write can touch the declaration more than once, and every touch is a
+  // record of its own: crediting one of them leaves us chasing our own writes.
+  private write (element: HTMLElement, apply: () => number): void {
+    const made = apply()
+    this.writes.set(element, (this.writes.get(element) ?? 0) + made)
     queueMicrotask(() => this.writes.delete(element))
   }
 

--- a/src/content/Filter/backgroundImageValue.ts
+++ b/src/content/Filter/backgroundImageValue.ts
@@ -1,4 +1,4 @@
-import valueParser, { Node } from 'postcss-value-parser'
+import valueParser from 'postcss-value-parser'
 
 const IMAGE_SET = new Set(['image-set', '-webkit-image-set'])
 
@@ -10,7 +10,7 @@ export const backgroundImageUrls = (value: string): string[] => {
   if (value === '' || value === 'none') return []
 
   const urls = new Set<string>()
-  const collect = (nodes: Node[], inImageSet: boolean): void => {
+  const collect = (nodes: valueParser.Node[], inImageSet: boolean): void => {
     for (const node of nodes) {
       if (node.type === 'function') {
         const name = node.value.toLowerCase()

--- a/src/content/Filter/backgroundImageValue.ts
+++ b/src/content/Filter/backgroundImageValue.ts
@@ -1,0 +1,37 @@
+import valueParser, { Node } from 'postcss-value-parser'
+
+const IMAGE_SET = new Set(['image-set', '-webkit-image-set'])
+
+// Computed `background-image` is a comma-separated stack of layers, and a layer
+// can bury a url inside image-set() or cross-fade(). Everything here works on the
+// computed value, which the browser has already resolved against the stylesheet's
+// own base url, so the strings come out absolute.
+export const backgroundImageUrls = (value: string): string[] => {
+  if (value === '' || value === 'none') return []
+
+  const urls = new Set<string>()
+  const collect = (nodes: Node[], inImageSet: boolean): void => {
+    for (const node of nodes) {
+      if (node.type === 'function') {
+        const name = node.value.toLowerCase()
+        if (name === 'url') {
+          const [argument] = node.nodes
+          if (argument !== undefined && argument.value !== '') urls.add(argument.value)
+          continue
+        }
+
+        collect(node.nodes, IMAGE_SET.has(name))
+        continue
+      }
+
+      // image-set() also takes bare strings as candidates, and which one the
+      // browser picked isn't observable. Its type() and resolution arguments are
+      // not candidates.
+      if (inImageSet && node.type === 'string' && node.value !== '') urls.add(node.value)
+    }
+  }
+
+  collect(valueParser(value).nodes, false)
+
+  return [...urls]
+}

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -7,6 +7,7 @@ import { isHostAllowed } from '../utils/allowlist'
 import { CONTEXT_TARGET, UNHIDE_IMAGE, UnhideImageMessage } from '../utils/messages'
 
 import { DOMWatcher } from './DOMWatcher/DOMWatcher'
+import { BackgroundImageFilter } from './Filter/BackgroundImageFilter'
 import { ImageFilter } from './Filter/ImageFilter'
 import { VideoFilter } from './Filter/VideoFilter'
 
@@ -73,7 +74,8 @@ const init = (): void => {
   // Ignore iframes for filtering, https://stackoverflow.com/a/326076/10432429
   if (window.self !== window.top) return
 
-  const domWatcher = new DOMWatcher(imageFilter, videoFilter)
+  const backgroundFilter = new BackgroundImageFilter()
+  const domWatcher = new DOMWatcher(imageFilter, videoFilter, backgroundFilter)
 
   injectPendingHide()
   const safety = setTimeout(removePendingHide, HIDE_STYLE_SAFETY_TIMEOUT)
@@ -98,6 +100,7 @@ const init = (): void => {
         domWatcher.watch()
       } else {
         // Extension turned off, or filtering disabled for this site: reveal everything.
+        backgroundFilter.stop()
         removePendingHide()
       }
 
@@ -125,13 +128,16 @@ const init = (): void => {
 
         if (filtering) {
           videoFilter.start()
+          backgroundFilter.start()
           domWatcher.watch()
         } else {
           domWatcher.unwatch()
+          backgroundFilter.stop()
           removePendingHide()
           imageFilter.revealAll()
           videoFilter.revealAll()
           videoFilter.stop()
+          backgroundFilter.revealAll()
         }
       })
     })
@@ -139,6 +145,7 @@ const init = (): void => {
       console.warn(error)
       imageFilter.setSettings({ filterEffect: 'blur' })
       videoFilter.setSettings({ filterEffect: 'blur' })
+      backgroundFilter.stop()
       clearTimeout(safety)
       removePendingHide()
     })

--- a/test/e2e/backgroundImage.test.js
+++ b/test/e2e/backgroundImage.test.js
@@ -169,6 +169,11 @@ describe('CSS background images', () => {
     const variable = await read(page, 'variable')
     expect(variable.status).toBe('sfw')
     expect(variable.backgroundImage).toContain('variable=1')
+    // The declaration the page wrote, not a resolved url standing in for it.
+    const shorthand = await page.evaluate(() =>
+      document.getElementById('variable').style.getPropertyValue('background')
+    )
+    expect(shorthand).toContain('var(--photo)')
   })
 
   test('leaves no background stuck missing or unprocessed', async () => {

--- a/test/e2e/backgroundImage.test.js
+++ b/test/e2e/backgroundImage.test.js
@@ -151,6 +151,26 @@ describe('CSS background images', () => {
     expect(promoted.backgroundImage).toContain('promoted=1')
   })
 
+  // A shorthand holding a custom property has no readable background-image
+  // longhand, so restoring one puts nothing back.
+  test('restores a background written as a shorthand with a variable', async () => {
+    await page.evaluate(() => {
+      const card = document.createElement('div')
+      card.id = 'variable'
+      card.textContent = 'variable text'
+      card.style.width = '128px'
+      card.style.height = '128px'
+      card.style.setProperty('--photo', 'url("/icon.png?variable=1")')
+      card.style.background = 'var(--photo)'
+      document.body.appendChild(card)
+    })
+    await settled(page, 'variable')
+
+    const variable = await read(page, 'variable')
+    expect(variable.status).toBe('sfw')
+    expect(variable.backgroundImage).toContain('variable=1')
+  })
+
   test('leaves no background stuck missing or unprocessed', async () => {
     const leftovers = await page.evaluate(() =>
       [...document.querySelectorAll('[data-nsfw-filter-background-status]')].filter(element => {

--- a/test/e2e/backgroundImage.test.js
+++ b/test/e2e/backgroundImage.test.js
@@ -1,0 +1,144 @@
+// CSS background images. They carry no <img> element, so nothing in the image
+// path sees them: discovery has to come from computed style. The fixture uses
+// the extension's own icon, which keeps the verdict independent of the network.
+
+const SETTLE_TIMEOUT = 60000
+
+const settled = async (page, id) => await page.waitForFunction((id) => {
+  const status = document.getElementById(id).getAttribute('data-nsfw-filter-background-status')
+  return status !== null && status !== 'processing'
+}, { timeout: SETTLE_TIMEOUT, polling: 250 }, id)
+
+const read = async (page, id) => await page.evaluate((id) => {
+  const element = document.getElementById(id)
+  return {
+    status: element.getAttribute('data-nsfw-filter-background-status'),
+    backgroundImage: getComputedStyle(element).backgroundImage,
+    textVisibility: getComputedStyle(element).visibility
+  }
+}, id)
+
+// A verdict already sitting on the element satisfies settled(), so a re-judgement
+// is only observable as a fresh trip back through processing.
+const recordStatuses = async (page, id) => await page.evaluate((id) => {
+  window.__bgStatuses = []
+  const element = document.getElementById(id)
+  new MutationObserver(() => window.__bgStatuses.push(
+    element.getAttribute('data-nsfw-filter-background-status')
+  )).observe(element, { attributes: true, attributeFilter: ['data-nsfw-filter-background-status'] })
+}, id)
+
+const reprocessed = async (page) => await page.waitForFunction(() =>
+  window.__bgStatuses.includes('processing'),
+{ timeout: SETTLE_TIMEOUT, polling: 250 })
+
+describe('CSS background images', () => {
+  let page
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage()
+    await page.goto(`${global.__BASE_URL__}background.html`, { waitUntil: 'load' })
+    await settled(page, 'sheet')
+    await settled(page, 'inline')
+  }, SETTLE_TIMEOUT)
+
+  afterAll(async () => {
+    await page.close()
+  })
+
+  test('classifies a background applied by a stylesheet and restores it', async () => {
+    const sheet = await read(page, 'sheet')
+    expect(sheet.status).toBe('sfw')
+    expect(sheet.backgroundImage).toContain('icon.png')
+    // The whole stack comes back, not just the layer that was classified.
+    expect(sheet.backgroundImage).toContain('gradient')
+  })
+
+  test('classifies a background applied inline and restores the declaration', async () => {
+    const inline = await read(page, 'inline')
+    expect(inline.status).toBe('sfw')
+    expect(inline.backgroundImage).toContain('icon.png')
+    expect(await page.evaluate(() =>
+      document.getElementById('inline').style.getPropertyValue('background-image')
+    )).toContain('icon.png')
+  })
+
+  // Hiding a background must never hide the element: its text belongs to the page.
+  test('leaves the element and its text visible throughout', async () => {
+    for (const id of ['sheet', 'inline']) {
+      expect((await read(page, id)).textVisibility).toBe('visible')
+    }
+  })
+
+  test('ignores an element with no background image', async () => {
+    const plain = await read(page, 'plain')
+    expect(plain.status).toBeNull()
+  })
+
+  // A virtualized list swaps the class and the same element shows different
+  // footage. The new background has to be judged on its own.
+  test('re-judges a background the page swaps out', async () => {
+    await recordStatuses(page, 'sheet')
+    await page.evaluate(() => {
+      document.getElementById('sheet').className = 'card-revised'
+    })
+    await reprocessed(page)
+    await page.waitForFunction(() =>
+      getComputedStyle(document.getElementById('sheet')).backgroundImage.includes('revision=2'),
+    { timeout: SETTLE_TIMEOUT, polling: 250 })
+    await settled(page, 'sheet')
+
+    const sheet = await read(page, 'sheet')
+    expect(sheet.status).toBe('sfw')
+    expect(sheet.backgroundImage).toContain('revision=2')
+  })
+
+  // A stylesheet arriving after load changes no attribute and moves nothing into
+  // the viewport, so nothing else would prompt a look at what it brings. Filling
+  // it in afterwards is how a framework usually gets there.
+  test('classifies a background introduced by a late stylesheet', async () => {
+    await page.evaluate(() => {
+      window.__sheet = document.head.appendChild(document.createElement('style'))
+    })
+    await page.evaluate(() => {
+      window.__sheet.textContent =
+        '#plain { width: 128px; height: 128px; background-image: url("/icon.png?late=1") }'
+    })
+    await settled(page, 'plain')
+
+    const plain = await read(page, 'plain')
+    expect(plain.status).toBe('sfw')
+    expect(plain.backgroundImage).toContain('late=1')
+  })
+
+  // The verdict for a detached element is dropped, so a removed card must not come
+  // back still carrying the override it was hidden with.
+  test('restores and re-judges a card removed while it was being classified', async () => {
+    await page.evaluate(() => {
+      const card = document.getElementById('inline')
+      window.__parked = card
+      card.remove()
+    })
+    await page.waitForFunction(() =>
+      window.__parked.getAttribute('data-nsfw-filter-background-status') === null &&
+      window.__parked.style.getPropertyValue('background-image') !== 'none',
+    { timeout: SETTLE_TIMEOUT, polling: 250 })
+
+    await page.evaluate(() => document.body.appendChild(window.__parked))
+    await settled(page, 'inline')
+
+    const inline = await read(page, 'inline')
+    expect(inline.status).toBe('sfw')
+    expect(inline.backgroundImage).toContain('icon.png')
+  })
+
+  test('leaves no background stuck missing or unprocessed', async () => {
+    const leftovers = await page.evaluate(() =>
+      [...document.querySelectorAll('[data-nsfw-filter-background-status]')].filter(element => {
+        const status = element.getAttribute('data-nsfw-filter-background-status')
+        return status === 'processing' || getComputedStyle(element).backgroundImage === 'none'
+      }).length
+    )
+    expect(leftovers).toBe(0)
+  })
+})

--- a/test/e2e/backgroundImage.test.js
+++ b/test/e2e/backgroundImage.test.js
@@ -132,6 +132,25 @@ describe('CSS background images', () => {
     expect(inline.backgroundImage).toContain('icon.png')
   })
 
+  // An id change can bring in a rule of its own, and nothing about the element
+  // moves or gains a class when it does.
+  test('classifies a background an id change brings in', async () => {
+    await page.evaluate(() => {
+      const card = document.createElement('div')
+      card.id = 'placeholder'
+      card.textContent = 'promoted text'
+      document.body.appendChild(card)
+    })
+    await page.evaluate(() => {
+      document.getElementById('placeholder').id = 'promoted'
+    })
+    await settled(page, 'promoted')
+
+    const promoted = await read(page, 'promoted')
+    expect(promoted.status).toBe('sfw')
+    expect(promoted.backgroundImage).toContain('promoted=1')
+  })
+
   test('leaves no background stuck missing or unprocessed', async () => {
     const leftovers = await page.evaluate(() =>
       [...document.querySelectorAll('[data-nsfw-filter-background-status]')].filter(element => {

--- a/test/e2e/fixtures/background.css
+++ b/test/e2e/fixtures/background.css
@@ -11,3 +11,9 @@
   height: 128px;
   background-image: url("/icon.png?revision=2");
 }
+
+#promoted {
+  width: 128px;
+  height: 128px;
+  background-image: url("/icon.png?promoted=1");
+}

--- a/test/e2e/fixtures/background.css
+++ b/test/e2e/fixtures/background.css
@@ -1,0 +1,13 @@
+/* An external stylesheet, so the url can only be found through computed style:
+   the element carries no inline style and the sheet is a separate request. */
+.card {
+  width: 128px;
+  height: 128px;
+  background-image: linear-gradient(transparent, transparent), url("/icon.png");
+}
+
+.card-revised {
+  width: 128px;
+  height: 128px;
+  background-image: url("/icon.png?revision=2");
+}

--- a/test/e2e/fixtures/background.html
+++ b/test/e2e/fixtures/background.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>NSFW Filter background fixture</title>
+  <link rel="stylesheet" href="/background.css">
+</head>
+<body>
+  <!-- Styled by the sheet above, present at document_start. -->
+  <div id="sheet" class="card">card text</div>
+  <!-- The same image, applied inline. -->
+  <div id="inline" style="width: 128px; height: 128px; background-image: url('/icon.png')">inline text</div>
+  <!-- No background at all: must never be tagged or touched. -->
+  <div id="plain">plain text</div>
+</body>
+</html>

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -58,7 +58,8 @@ const launchOptions = ({ webgl = true } = {}) => ({
 const CONTENT_TYPES = {
   '.html': 'text/html',
   '.png': 'image/png',
-  '.webm': 'video/webm'
+  '.webm': 'video/webm',
+  '.css': 'text/css'
 }
 
 // A small static server so tests run against local fixtures instead of remote

--- a/test/unit/BackgroundImageFilter.test.ts
+++ b/test/unit/BackgroundImageFilter.test.ts
@@ -63,7 +63,11 @@ const flush = async (): Promise<void> => {
   await Promise.resolve()
 }
 
-afterEach(() => { document.body.innerHTML = '' })
+afterEach(() => {
+  // A failing test must not leave fake timers behind for the next one.
+  jest.useRealTimers()
+  document.body.innerHTML = ''
+})
 
 describe('content => BackgroundImageFilter', () => {
   test('removes the background while it is being classified', () => {
@@ -191,7 +195,6 @@ describe('content => BackgroundImageFilter', () => {
 
     expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
     expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
-    jest.useRealTimers()
   })
 
   test('restores every background it removed when filtering is turned off', async () => {
@@ -395,6 +398,5 @@ describe('content => BackgroundImageFilter => rechecks', () => {
 
     expect(read).toHaveBeenCalledWith(element)
     read.mockRestore()
-    jest.useRealTimers()
   })
 })

--- a/test/unit/BackgroundImageFilter.test.ts
+++ b/test/unit/BackgroundImageFilter.test.ts
@@ -361,6 +361,80 @@ describe('content => BackgroundImageFilter => rechecks', () => {
     read.mockRestore()
   })
 
+  // A recheck restores the declaration and puts the override back, which is more
+  // than one write to it. Crediting one leaves the rest looking like the page,
+  // and the filter chasing its own writes for the life of the tab.
+  test('settles instead of chasing the writes a recheck makes', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    runtime.release(true)
+    await flush()
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('nsfw')
+
+    let records = 0
+    const observer = new MutationObserver(list => {
+      records += list.length
+      list.forEach(() => filter.checkStyleMutation(element))
+    })
+    observer.observe(element, { attributes: true, attributeFilter: ['style'] })
+
+    filter.recheckVisible()
+    await flush()
+    await flush()
+    const settled = records
+
+    await flush()
+    await flush()
+    observer.disconnect()
+
+    expect(records).toBe(settled)
+  })
+
+  // `.card[style]` is a selector like any other: an empty attribute left behind
+  // is a background of its own.
+  test('leaves no style attribute behind on an element that had none', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+
+    const element = document.createElement('div')
+    element.getBoundingClientRect = () => ({ width: 200, height: 200 } as DOMRect)
+    document.body.appendChild(element)
+    const read = jest.spyOn(window, 'getComputedStyle')
+      .mockImplementation(() => ({ backgroundImage: `url("${IMAGE}")` }) as unknown as CSSStyleDeclaration)
+
+    const filter = new BackgroundImageFilter()
+    filter.observe(element)
+    intersect(element, true)
+    expect(element.style.getPropertyValue('background-image')).toBe('none')
+
+    runtime.release(false)
+    await flush()
+    read.mockRestore()
+
+    expect(element.hasAttribute('style')).toBe(false)
+  })
+
+  // A short body still paints its background across the whole viewport.
+  test('classifies a body background whatever box the body has', () => {
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    document.body.setAttribute('style', `background-image: url("${IMAGE}")`)
+    document.body.getBoundingClientRect = () => ({ width: 1000, height: 8 } as DOMRect)
+
+    const filter = new BackgroundImageFilter()
+    filter.observe(document.body)
+    intersect(document.body, true)
+
+    expect(document.body.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+    document.body.removeAttribute('style')
+    delete document.body.dataset.nsfwFilterBackgroundStatus
+  })
+
   // `.selected + .card` puts the affected element beside the changed one.
   test('re-reads a visible sibling of a changed element', async () => {
     stubRuntime()

--- a/test/unit/BackgroundImageFilter.test.ts
+++ b/test/unit/BackgroundImageFilter.test.ts
@@ -1,0 +1,400 @@
+/**
+ * @jest-environment jsdom
+ */
+import { BackgroundImageFilter } from '../../src/content/Filter/BackgroundImageFilter'
+
+const IMAGE = 'http://example.com/a.jpg'
+
+type Intersect = (element: HTMLElement, isIntersecting: boolean) => void
+
+// One observer per filter; the test drives intersections by hand.
+const stubIntersectionObserver = (): { intersect: Intersect } => {
+  let callback: IntersectionObserverCallback = () => {}
+
+  class Stub {
+    constructor (handler: IntersectionObserverCallback) { callback = handler }
+    observe (): void {}
+    unobserve (): void {}
+    disconnect (): void {}
+  }
+
+  ;(global as unknown as { IntersectionObserver: unknown }).IntersectionObserver = Stub
+
+  return {
+    intersect: (element, isIntersecting) => callback(
+      [{ target: element, isIntersecting } as unknown as IntersectionObserverEntry],
+      {} as IntersectionObserver
+    )
+  }
+}
+
+// chrome.runtime.sendMessage, with each verdict held until the test releases it.
+const stubRuntime = (): { release: (result: boolean) => void, sent: () => number } => {
+  const pending: Array<(result: boolean) => void> = []
+
+  ;(global as unknown as { chrome: unknown }).chrome = {
+    runtime: {
+      lastError: undefined,
+      sendMessage: (message: { url: string }, respond: (response: unknown) => void) => {
+        pending.push(result => respond({ result, url: message.url }))
+      }
+    }
+  }
+
+  return {
+    release: (result: boolean) => pending.shift()?.(result),
+    sent: () => pending.length
+  }
+}
+
+const makeElement = (style = `background-image: url("${IMAGE}")`): HTMLElement => {
+  const element = document.createElement('div')
+  element.setAttribute('style', style)
+  element.getBoundingClientRect = () => ({ width: 200, height: 200 } as DOMRect)
+  document.body.appendChild(element)
+
+  return element
+}
+
+// Rechecks are coalesced into a task of their own, so draining the timer queue is
+// part of settling.
+const flush = async (): Promise<void> => {
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+afterEach(() => { document.body.innerHTML = '' })
+
+describe('content => BackgroundImageFilter', () => {
+  test('removes the background while it is being classified', () => {
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+    expect(element.style.getPropertyValue('background-image')).toBe('none')
+  })
+
+  test('puts a safe background back exactly as the page wrote it', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+    runtime.release(false)
+    await flush()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
+    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+    expect(element.style.getPropertyPriority('background-image')).toBe('')
+  })
+
+  test('leaves an unsafe background removed', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+    runtime.release(true)
+    await flush()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('nsfw')
+    expect(element.style.getPropertyValue('background-image')).toBe('none')
+  })
+
+  // The element itself must stay untouched: its text is the page's, not ours.
+  test('never hides the element carrying the background', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    element.textContent = 'card text'
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+    runtime.release(true)
+    await flush()
+
+    expect(element.style.visibility).toBe('')
+    expect(element.style.filter).toBe('')
+    expect(element.hidden).toBe(false)
+  })
+
+  test('ignores an element with no background image', () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement('width: 200px')
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(runtime.sent()).toBe(0)
+  })
+
+  test('leaves an element smaller than the minimum alone', () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    element.getBoundingClientRect = () => ({ width: 20, height: 20 } as DOMRect)
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(runtime.sent()).toBe(0)
+  })
+
+  // A recycled list row shows another item's background before the first verdict
+  // lands. The verdict belongs to footage this element no longer shows.
+  test('drops a verdict for a background the element has replaced', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    // Our own write is tracked until the observer has seen it, so the page's write
+    // has to come from a later task to count as the page's.
+    await Promise.resolve()
+    element.setAttribute('style', 'background-image: url("http://example.com/b.jpg")')
+    filter.checkStyleMutation(element)
+    await flush()
+    runtime.release(true)
+    await flush()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+  })
+
+  // Nothing downstream is guaranteed to answer. A background the page owns is
+  // not ours to keep off the screen.
+  test('restores the background when the background worker never answers', async () => {
+    jest.useFakeTimers()
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const { intersect } = stubIntersectionObserver()
+    ;(global as unknown as { chrome: unknown }).chrome = {
+      runtime: {
+        lastError: { message: 'Could not establish connection' },
+        sendMessage: (_message: unknown, respond: (response: unknown) => void) => respond(undefined)
+      }
+    }
+    const element = makeElement()
+
+    new BackgroundImageFilter().observe(element)
+    intersect(element, true)
+    await jest.advanceTimersByTimeAsync(5000)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
+    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+    jest.useRealTimers()
+  })
+
+  test('restores every background it removed when filtering is turned off', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    runtime.release(true)
+    await flush()
+    filter.stop()
+    filter.revealAll()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+  })
+})
+
+describe('content => BackgroundImageFilter => lifecycle', () => {
+  // Observing an element again is a no-op, so turning filtering back on produces
+  // no intersection for anything already on screen.
+  test('re-reads what is on screen when filtering resumes', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    runtime.release(false)
+    await flush()
+    filter.stop()
+    filter.revealAll()
+    filter.start()
+    await flush()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+    expect(element.style.getPropertyValue('background-image')).toBe('none')
+  })
+
+  // The verdict for a detached element is dropped, so nothing else would clear
+  // the override it is carrying when it comes back.
+  test('restores a removed element still waiting for a verdict', async () => {
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    element.remove()
+    filter.release(element)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+  })
+
+  test('classifies a reinserted element again', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    element.remove()
+    filter.release(element)
+    document.body.appendChild(element)
+    filter.observe(element)
+    intersect(element, true)
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+
+    runtime.release(false)
+    await flush()
+
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
+    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+  })
+
+  // The url lives in a custom property, so swapping it leaves our override in
+  // place: an intact override is no proof the write was ours.
+  test('re-reads a background swapped through a custom property', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    runtime.release(true)
+    await flush()
+    await Promise.resolve()
+
+    const read = jest.spyOn(window, 'getComputedStyle')
+    element.style.setProperty('--photo', 'nothing')
+    filter.checkStyleMutation(element)
+    await flush()
+
+    expect(read).toHaveBeenCalledWith(element)
+    read.mockRestore()
+  })
+
+  // Our own hide reaches the observer as a style mutation like any other.
+  test('does not re-read its own write', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    filter.checkStyleMutation(element)
+    await flush()
+
+    expect(runtime.sent()).toBe(1)
+  })
+
+  // Moving a card under a different parent can select a different background
+  // without touching its class or its style.
+  test('classifies a moved element against its new parent', async () => {
+    const runtime = stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+    runtime.release(false)
+    await flush()
+
+    const wrapper = document.createElement('div')
+    document.body.appendChild(wrapper)
+    wrapper.appendChild(element)
+    filter.release(element)
+    filter.observe(element)
+    await flush()
+
+    expect(runtime.sent()).toBe(1)
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
+  })
+})
+
+describe('content => BackgroundImageFilter => rechecks', () => {
+  // A page observing its own DOM can answer our override with a background of its
+  // own, in the same batch of mutations. Only the first of those is ours.
+  test('examines a page write that follows its own', async () => {
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+
+    const read = jest.spyOn(window, 'getComputedStyle')
+    filter.checkStyleMutation(element)
+    filter.checkStyleMutation(element)
+    await flush()
+
+    expect(read).toHaveBeenCalledWith(element)
+    read.mockRestore()
+  })
+
+  // `.selected + .card` puts the affected element beside the changed one.
+  test('re-reads a visible sibling of a changed element', async () => {
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const sibling = makeElement('width: 200px')
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(document.body)
+    intersect(element, true)
+    await flush()
+
+    const read = jest.spyOn(window, 'getComputedStyle')
+    filter.checkElement(sibling)
+    await flush()
+
+    expect(read).toHaveBeenCalledWith(element)
+    read.mockRestore()
+  })
+
+  // Crossing a breakpoint swaps the background with nothing else changing.
+  test('re-reads what is on screen after a resize', async () => {
+    jest.useFakeTimers()
+    stubRuntime()
+    const { intersect } = stubIntersectionObserver()
+    const element = makeElement()
+    const filter = new BackgroundImageFilter()
+
+    filter.observe(element)
+    intersect(element, true)
+
+    const read = jest.spyOn(window, 'getComputedStyle')
+    window.dispatchEvent(new Event('resize'))
+    await jest.advanceTimersByTimeAsync(500)
+
+    expect(read).toHaveBeenCalledWith(element)
+    read.mockRestore()
+    jest.useRealTimers()
+  })
+})

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -4,6 +4,7 @@
 import { DOMWatcher } from '../../src/content/DOMWatcher/DOMWatcher'
 import { IBackgroundImageFilter } from '../../src/content/Filter/BackgroundImageFilter'
 import { IImageFilter, ImageFilter } from '../../src/content/Filter/ImageFilter'
+import { IVideoFilter } from '../../src/content/Filter/VideoFilter'
 
 const flushMutations = async (): Promise<void> => await Promise.resolve()
 
@@ -12,6 +13,17 @@ const makeFilter = (): IImageFilter => ({
   setSettings: jest.fn(),
   revealImage: jest.fn(),
   checkStyleMutation: jest.fn()
+})
+
+const makeVideoFilter = (): IVideoFilter => ({
+  analyzeVideo: jest.fn(),
+  checkPoster: jest.fn(),
+  revealVideo: jest.fn(),
+  checkStyleMutation: jest.fn(),
+  applyEffectToBlocked: jest.fn(),
+  revealAll: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn()
 })
 
 const makeBackgroundFilter = (): IBackgroundImageFilter => ({
@@ -33,7 +45,7 @@ describe('content => DOMWatcher => watch', () => {
     document.body.innerHTML = '<img id="a"><img id="b">'
     const filter = makeFilter()
 
-    new DOMWatcher(filter, makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
 
     expect(filter.analyzeImage).toHaveBeenCalledTimes(2)
     expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'), false)
@@ -42,7 +54,7 @@ describe('content => DOMWatcher => watch', () => {
 
   test('checks images added after watching starts', async () => {
     const filter = makeFilter()
-    new DOMWatcher(filter, makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
 
     document.body.appendChild(document.createElement('img'))
     await flushMutations()
@@ -53,7 +65,7 @@ describe('content => DOMWatcher => watch', () => {
   test('reanalyzes an image when its src attribute changes', async () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
-    new DOMWatcher(filter, makeBackgroundFilter()).watch();
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch();
     (filter.analyzeImage as jest.Mock).mockClear()
 
     document.getElementById('a')!.setAttribute('src', 'http://example.com/a.jpg')
@@ -71,7 +83,7 @@ describe('content => DOMWatcher => start/stop live', () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
 
-    const watcher = new DOMWatcher(filter, makeBackgroundFilter())
+    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter())
     watcher.watch()
     watcher.watch()
 
@@ -80,7 +92,7 @@ describe('content => DOMWatcher => start/stop live', () => {
 
   test('unwatch stops reacting to later mutations', async () => {
     const filter = makeFilter()
-    const watcher = new DOMWatcher(filter, makeBackgroundFilter())
+    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter())
     watcher.watch()
     watcher.unwatch();
     (filter.analyzeImage as jest.Mock).mockClear()
@@ -106,7 +118,7 @@ describe('content => DOMWatcher => style rewrites (issue #244)', () => {
 
     const filter = new ImageFilter()
     filter.setSettings({ filterEffect: 'hide' })
-    new DOMWatcher(filter, makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
 
     image.setAttribute('style', 'visibility: visible')
     await flushMutations()
@@ -121,7 +133,7 @@ describe('content => DOMWatcher => cascade changes', () => {
   test('re-reads the parent of an inserted sibling', async () => {
     document.body.innerHTML = '<div id="list"><div id="card"></div></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
 
     document.getElementById('list')?.prepend(document.createElement('div'))
     await flushMutations()
@@ -132,7 +144,7 @@ describe('content => DOMWatcher => cascade changes', () => {
   test('re-reads what is on screen when a stylesheet is removed', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
     ;(background.recheckVisible as jest.Mock).mockClear()
 
     document.getElementById('sheet')?.remove()
@@ -146,7 +158,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('re-reads what is on screen when a wrapper holding a stylesheet is removed', async () => {
     document.body.innerHTML = '<div id="wrapper"><style></style></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
     ;(background.recheckVisible as jest.Mock).mockClear()
 
     document.getElementById('wrapper')?.remove()
@@ -158,7 +170,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('re-reads what is on screen when an id change brings in a new rule', async () => {
     document.body.innerHTML = '<div id="card"></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
 
     const card = document.getElementById('card') as HTMLElement
     card.id = 'other'
@@ -172,7 +184,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('stops watching a stylesheet the page removed', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
 
     const sheet = document.getElementById('sheet') as HTMLElement
     sheet.remove()
@@ -190,7 +202,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('stops watching stylesheets when watching stops', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    const watcher = new DOMWatcher(makeFilter(), background)
+    const watcher = new DOMWatcher(makeFilter(), makeVideoFilter(), background)
     watcher.watch()
     watcher.unwatch()
     ;(background.recheckVisible as jest.Mock).mockClear()

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -141,3 +141,46 @@ describe('content => DOMWatcher => cascade changes', () => {
     expect(background.recheckVisible).toHaveBeenCalled()
   })
 })
+
+describe('content => DOMWatcher => stylesheet registrations', () => {
+  test('re-reads what is on screen when a wrapper holding a stylesheet is removed', async () => {
+    document.body.innerHTML = '<div id="wrapper"><style></style></div>'
+    const background = makeBackgroundFilter()
+    new DOMWatcher(makeFilter(), background).watch()
+    ;(background.recheckVisible as jest.Mock).mockClear()
+
+    document.getElementById('wrapper')?.remove()
+    await flushMutations()
+
+    expect(background.recheckVisible).toHaveBeenCalled()
+  })
+
+  test('re-reads what is on screen when an id change brings in a new rule', async () => {
+    document.body.innerHTML = '<div id="card"></div>'
+    const background = makeBackgroundFilter()
+    new DOMWatcher(makeFilter(), background).watch()
+
+    const card = document.getElementById('card') as HTMLElement
+    card.id = 'other'
+    await flushMutations()
+
+    expect(background.checkElement).toHaveBeenCalledWith(card)
+  })
+
+  // Each <style> carries its own observer, so a pause that left them running
+  // would keep answering for a filter that is meant to be idle.
+  test('stops watching stylesheets when watching stops', async () => {
+    document.body.innerHTML = '<style id="sheet"></style>'
+    const background = makeBackgroundFilter()
+    const watcher = new DOMWatcher(makeFilter(), background)
+    watcher.watch()
+    watcher.unwatch()
+    ;(background.recheckVisible as jest.Mock).mockClear()
+
+    const sheet = document.getElementById('sheet') as HTMLElement
+    sheet.textContent = '.card { background-image: url("http://example.com/a.jpg") }'
+    await flushMutations()
+
+    expect(background.recheckVisible).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -167,6 +167,24 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
     expect(background.checkElement).toHaveBeenCalledWith(card)
   })
 
+  // A page that mounts a style per render leaves one observer per unmount unless
+  // the removal takes it with it.
+  test('stops watching a stylesheet the page removed', async () => {
+    document.body.innerHTML = '<style id="sheet"></style>'
+    const background = makeBackgroundFilter()
+    new DOMWatcher(makeFilter(), background).watch()
+
+    const sheet = document.getElementById('sheet') as HTMLElement
+    sheet.remove()
+    await flushMutations()
+    ;(background.recheckVisible as jest.Mock).mockClear()
+
+    sheet.textContent = '.card { background-image: url("http://example.com/a.jpg") }'
+    await flushMutations()
+
+    expect(background.recheckVisible).not.toHaveBeenCalled()
+  })
+
   // Each <style> carries its own observer, so a pause that left them running
   // would keep answering for a filter that is meant to be idle.
   test('stops watching stylesheets when watching stops', async () => {

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { DOMWatcher } from '../../src/content/DOMWatcher/DOMWatcher'
+import { IBackgroundImageFilter } from '../../src/content/Filter/BackgroundImageFilter'
 import { IImageFilter, ImageFilter } from '../../src/content/Filter/ImageFilter'
 
 const flushMutations = async (): Promise<void> => await Promise.resolve()
@@ -13,6 +14,18 @@ const makeFilter = (): IImageFilter => ({
   checkStyleMutation: jest.fn()
 })
 
+const makeBackgroundFilter = (): IBackgroundImageFilter => ({
+  observe: jest.fn(),
+  release: jest.fn(),
+  recheckVisible: jest.fn(),
+  checkElement: jest.fn(),
+  checkStyleMutation: jest.fn(),
+  applyEffectToBlocked: jest.fn(),
+  revealAll: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn()
+})
+
 afterEach(() => { document.body.innerHTML = '' })
 
 describe('content => DOMWatcher => watch', () => {
@@ -20,7 +33,7 @@ describe('content => DOMWatcher => watch', () => {
     document.body.innerHTML = '<img id="a"><img id="b">'
     const filter = makeFilter()
 
-    new DOMWatcher(filter).watch()
+    new DOMWatcher(filter, makeBackgroundFilter()).watch()
 
     expect(filter.analyzeImage).toHaveBeenCalledTimes(2)
     expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'), false)
@@ -29,7 +42,7 @@ describe('content => DOMWatcher => watch', () => {
 
   test('checks images added after watching starts', async () => {
     const filter = makeFilter()
-    new DOMWatcher(filter).watch()
+    new DOMWatcher(filter, makeBackgroundFilter()).watch()
 
     document.body.appendChild(document.createElement('img'))
     await flushMutations()
@@ -40,7 +53,7 @@ describe('content => DOMWatcher => watch', () => {
   test('reanalyzes an image when its src attribute changes', async () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
-    new DOMWatcher(filter).watch();
+    new DOMWatcher(filter, makeBackgroundFilter()).watch();
     (filter.analyzeImage as jest.Mock).mockClear()
 
     document.getElementById('a')!.setAttribute('src', 'http://example.com/a.jpg')
@@ -58,7 +71,7 @@ describe('content => DOMWatcher => start/stop live', () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
 
-    const watcher = new DOMWatcher(filter)
+    const watcher = new DOMWatcher(filter, makeBackgroundFilter())
     watcher.watch()
     watcher.watch()
 
@@ -67,7 +80,7 @@ describe('content => DOMWatcher => start/stop live', () => {
 
   test('unwatch stops reacting to later mutations', async () => {
     const filter = makeFilter()
-    const watcher = new DOMWatcher(filter)
+    const watcher = new DOMWatcher(filter, makeBackgroundFilter())
     watcher.watch()
     watcher.unwatch();
     (filter.analyzeImage as jest.Mock).mockClear()
@@ -93,7 +106,7 @@ describe('content => DOMWatcher => style rewrites (issue #244)', () => {
 
     const filter = new ImageFilter()
     filter.setSettings({ filterEffect: 'hide' })
-    new DOMWatcher(filter).watch()
+    new DOMWatcher(filter, makeBackgroundFilter()).watch()
 
     image.setAttribute('style', 'visibility: visible')
     await flushMutations()

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -114,3 +114,30 @@ describe('content => DOMWatcher => style rewrites (issue #244)', () => {
     expect(image.style.visibility).toBe('hidden')
   })
 })
+
+// A background can be selected by what is around an element rather than by the
+// element itself, so what changed is not always what has to be re-read.
+describe('content => DOMWatcher => cascade changes', () => {
+  test('re-reads the parent of an inserted sibling', async () => {
+    document.body.innerHTML = '<div id="list"><div id="card"></div></div>'
+    const background = makeBackgroundFilter()
+    new DOMWatcher(makeFilter(), background).watch()
+
+    document.getElementById('list')?.prepend(document.createElement('div'))
+    await flushMutations()
+
+    expect(background.checkElement).toHaveBeenCalledWith(document.getElementById('list'))
+  })
+
+  test('re-reads what is on screen when a stylesheet is removed', async () => {
+    document.body.innerHTML = '<style id="sheet"></style>'
+    const background = makeBackgroundFilter()
+    new DOMWatcher(makeFilter(), background).watch()
+    ;(background.recheckVisible as jest.Mock).mockClear()
+
+    document.getElementById('sheet')?.remove()
+    await flushMutations()
+
+    expect(background.recheckVisible).toHaveBeenCalled()
+  })
+})

--- a/test/unit/backgroundImageValue.test.ts
+++ b/test/unit/backgroundImageValue.test.ts
@@ -1,0 +1,48 @@
+import { backgroundImageUrls } from '../../src/content/Filter/backgroundImageValue'
+
+describe('content => backgroundImageValue', () => {
+  test('reads the url out of a single layer', () => {
+    expect(backgroundImageUrls('url("http://example.com/a.jpg")')).toEqual(['http://example.com/a.jpg'])
+  })
+
+  test('reads every layer of a stack', () => {
+    const value = 'url("http://example.com/a.jpg"), url("http://example.com/b.jpg")'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/a.jpg', 'http://example.com/b.jpg'])
+  })
+
+  test('ignores gradients', () => {
+    expect(backgroundImageUrls('linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255))')).toEqual([])
+    expect(backgroundImageUrls('none')).toEqual([])
+    expect(backgroundImageUrls('')).toEqual([])
+  })
+
+  test('finds a url a gradient layer is stacked over', () => {
+    const value = 'linear-gradient(transparent, transparent), url("http://example.com/a.jpg")'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/a.jpg'])
+  })
+
+  // Which candidate the browser picked isn't observable from here.
+  test('takes every candidate of an image-set', () => {
+    const value = 'image-set(url("http://example.com/1x.jpg") 1x, "http://example.com/2x.jpg" 2x)'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/1x.jpg', 'http://example.com/2x.jpg'])
+  })
+
+  test('deduplicates a url used by more than one layer', () => {
+    const value = 'url("http://example.com/a.jpg"), url("http://example.com/a.jpg")'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/a.jpg'])
+  })
+})
+
+// image-set() carries more than candidates: a type() hint is not something to
+// send to the model.
+describe('content => backgroundImageValue => image-set arguments', () => {
+  test('skips the type hint of an image-set candidate', () => {
+    const value = 'image-set(url("http://example.com/a.avif") type("image/avif") 1x)'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/a.avif'])
+  })
+
+  test('skips a quoted gradient argument that is not a candidate', () => {
+    const value = 'cross-fade(url("http://example.com/a.jpg"), "not-a-candidate")'
+    expect(backgroundImageUrls(value)).toEqual(['http://example.com/a.jpg'])
+  })
+})


### PR DESCRIPTION
Closes #46. Picks up where #167 and #269 left off.

An image set through CSS carries no `<img>` element, so nothing in the image path ever saw it. This adds a `BackgroundImageFilter` that discovers backgrounds from computed style as elements come near the viewport.

#### Changes

- `BackgroundImageFilter`: registers every element through a `TreeWalker`, reads computed style when an element comes within 300px of the viewport, and classifies the whole background stack as one unit. One unsafe layer blocks the stack, since the layers are positioned against each other.
- Blocked and pending backgrounds are removed with `background-image: none !important`, never `visibility` or `filter`, which would take the element's text and children with it. The exact inline declaration is saved and put back on a safe verdict, so the cascade returns as the page wrote it.
- `backgroundImageValue.ts` parses the computed value with `postcss-value-parser` (promoted from a transitive to a direct dependency), covering `image-set()` candidates and urls nested in gradients.
- `DOMWatcher` routes style and class mutations to both filters, registers added subtrees, restores and invalidates removed ones, and rechecks what is on screen when a stylesheet arrives or is filled in.
- Rechecks are coalesced into one pass per task, and a media-query swap is caught through a debounced resize.

#### Testing

- 18 unit tests for the filter and 8 for the parser, covering restoration, recycled elements, removal and reinsertion, resume after a pause, sibling rules, and the fail-open deadline.
- 6 e2e tests against a fixture served from an external stylesheet: restoration with the gradient intact, the element's text staying visible, a re-judged class swap, a late stylesheet, and a card removed mid-classification.
- Full suite green on both the dev and the production bundle: 85 unit tests, 19 e2e passed / 8 network-gated skips. `tsc --noEmit` and `eslint src/` clean.

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering for images used as CSS backgrounds, including inline styles, stylesheets, layered backgrounds, image sets, and shorthand declarations.
  * Unsafe background images are hidden while preserving surrounding page content.
  * Background filtering responds to style, class, identifier, stylesheet, resize, visibility, and DOM changes.
  * Safe backgrounds are restored when filtering is disabled or classification completes safely.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for background-image detection, filtering, lifecycle changes, and dynamic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->