### PR TITLE
chore: bump version to 3.1.1

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "NSFW Filter",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Free, open source, and privacy-focused browser extension to block \"not safe for work\" content.",
   "author": "Navendu Pottekkat",
   "homepage_url": "https://nsfw-filter.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nsfw-filter",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nsfw-filter",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tensorflow/tfjs": "4.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nsfw-filter",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Free, open source, and privacy-focused browser extension to block \"not safe for work\" content.",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
#### Changes

Bumps the version to 3.1.1 in `package.json`, `package-lock.json` and `dist/manifest.json`, the same three files the 3.1.0 bump touched.

#### Testing

Verified on a clean checkout of master with the bump applied:

- 131 unit tests passing
- e2e 30 passed / 8 network-gated skips, on both the production and development bundles
- `tsc --noEmit` and `eslint src/` clean
- production bundle rebuilt from a clean `npm run build`

#### Type of change

- [x] Chore

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 3.1.0 to 3.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->