### PR TITLE
Filter canvas, shadow DOM, animations and iframes

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -23,6 +23,18 @@
       ],
       "js": ["src/content.js"],
       "all_frames": true,
+      "match_origin_as_fallback": true,
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": ["src/mediaGuard.js"],
+      "world": "MAIN",
+      "all_frames": true,
+      "match_origin_as_fallback": true,
       "run_at": "document_start"
     }
   ],

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,7 +5,13 @@ import { StatisticsActionTypes } from '../popup/redux/actions/statistics'
 import { createChromeStore } from '../popup/redux/chrome-storage'
 import { rootReducer, RootState } from '../popup/redux/reducers'
 import { ILogger, Logger } from '../utils/Logger'
-import { CONTEXT_TARGET, ContextTargetMessage, PredictionResponse, UNHIDE_IMAGE } from '../utils/messages'
+import {
+  CONTEXT_TARGET,
+  ContextTargetMessage,
+  PAGE_HOST,
+  PredictionResponse,
+  UNHIDE_IMAGE
+} from '../utils/messages'
 
 import { OffscreenModel } from './OffscreenModel'
 import { DEFAULT_TAB_ID, TabIdUrl } from './Queue/QueueBase'
@@ -185,7 +191,7 @@ const createUnhideMenu = (): void => {
     chrome.contextMenus.create({
       id: UNHIDE_MENU_ID,
       title: 'Unhide this (NSFW Filter)',
-      contexts: ['image', 'video'],
+      contexts: ['all'],
       visible: false
     })
   })
@@ -238,6 +244,23 @@ chrome.runtime.onMessage.addListener((request: IncomingMessage, sender, sendResp
     .catch(err => sendResponse(new PredictionResponse(false, url, err?.message)))
 
   return true // https://stackoverflow.com/a/56483156
+})
+
+// Every frame follows the user's choice for the page in the tab. A cross-origin
+// child cannot read that URL itself; sender.tab is supplied by Chrome.
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request?.type !== PAGE_HOST) return
+  for (const url of [sender.tab?.url, sender.origin, sender.url]) {
+    if (url === undefined) continue
+    try {
+      const host = new URL(url).hostname
+      if (host !== '') {
+        sendResponse(host)
+        return
+      }
+    } catch { /* An opaque origin has no hostname. */ }
+  }
+  sendResponse('')
 })
 
 // When user opened a new tab

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -116,12 +116,12 @@ export class DOMWatcher implements IDOMWatcher {
         if (mutation.target instanceof HTMLElement) this.backgroundFilter.checkElement(mutation.target)
         if (mutation.addedNodes.length === 0) continue
 
-        this.findAndCheckAllMedia(mutation.target as ParentNode)
-        // Backgrounds are registered per added subtree rather than by re-walking
-        // the mutation target: a feed appending rows would otherwise re-walk the
-        // whole feed on every row.
+        // Registered per added subtree rather than by re-walking the mutation
+        // target: a feed appending rows would otherwise re-walk the whole feed
+        // on every row.
         mutation.addedNodes.forEach(node => {
           if (!(node instanceof Element)) return
+          this.findAndCheckAllMedia(node)
           this.backgroundFilter.observe(node)
           this.watchStyleSheets(node)
         })
@@ -214,6 +214,10 @@ export class DOMWatcher implements IDOMWatcher {
     const detached = [...this.roots].filter(root => root instanceof ShadowRoot && !root.host.isConnected)
     if (detached.length === 0) return
     for (const root of detached) this.roots.delete(root)
+    // disconnect() empties the record queue as well as the target list, so drain
+    // it first: media in an undelivered record would otherwise never be seen,
+    // and the pending rule would keep it hidden.
+    this.callback(this.observer.takeRecords())
     this.observer.disconnect()
     for (const root of this.roots) this.observer.observe(root, DOMWatcher.getConfig())
   }

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -1,13 +1,18 @@
 // Highly sensitive code, make sure that you know what you're doing
 // https://stackoverflow.com/a/39332340/10432429
 
-// @TODO Canvas and SVG
-
 import { IBackgroundImageFilter } from '../Filter/BackgroundImageFilter'
-import { IImageFilter } from '../Filter/ImageFilter'
+import { ICanvasFilter } from '../Filter/CanvasFilter'
+import { IImageFilter, ImageElement } from '../Filter/ImageFilter'
 import { IVideoFilter } from '../Filter/VideoFilter'
+import { CANVAS_DRAWN, SHADOW_ROOT_CREATED } from '../mediaChanges'
+import { mediaRoots, shadowRootOf, MediaRoot } from '../mediaRoots'
+
+import { injectPendingHide } from './pendingStyle'
 
 const STYLE_SHEET = 'link[rel~="stylesheet"], style'
+const MEDIA_SELECTOR = 'img,video,canvas,svg image'
+const BACKGROUND_EVENTS = ['pointerover', 'pointerout', 'focusin', 'focusout']
 
 export type IDOMWatcher = {
   watch: () => void
@@ -19,6 +24,9 @@ export class DOMWatcher implements IDOMWatcher {
   private readonly imageFilter: IImageFilter
   private readonly videoFilter: IVideoFilter
   private readonly backgroundFilter: IBackgroundImageFilter
+  private readonly canvasFilter: ICanvasFilter
+  private readonly roots = new Set<MediaRoot>()
+  private rootTimer: ReturnType<typeof setInterval> | undefined
   private sheetObservers: Map<Element, MutationObserver>
   private sheetLoads: AbortController
   private registered: WeakSet<Element>
@@ -27,11 +35,13 @@ export class DOMWatcher implements IDOMWatcher {
   constructor (
     imageFilter: IImageFilter,
     videoFilter: IVideoFilter,
-    backgroundFilter: IBackgroundImageFilter
+    backgroundFilter: IBackgroundImageFilter,
+    canvasFilter: ICanvasFilter
   ) {
     this.imageFilter = imageFilter
     this.videoFilter = videoFilter
     this.backgroundFilter = backgroundFilter
+    this.canvasFilter = canvasFilter
     this.observer = new MutationObserver(this.callback.bind(this))
     this.sheetObservers = new Map()
     this.sheetLoads = new AbortController()
@@ -46,12 +56,20 @@ export class DOMWatcher implements IDOMWatcher {
     this.watching = true
 
     this.observer.observe(document, DOMWatcher.getConfig())
+    this.roots.add(document)
+    document.addEventListener(SHADOW_ROOT_CREATED, this.onShadowRootCreated)
+    document.addEventListener(CANVAS_DRAWN, this.onCanvasDrawn, true)
+    this.watchBackgroundInteractions(document)
+    injectPendingHide(document)
     // The observer only reports future mutations. Sweep the media already in the
     // DOM so anything parsed before the (async) store resolved is still hidden
     // and classified instead of missed.
     this.findAndCheckAllMedia(document.documentElement)
     this.backgroundFilter.observe(document.documentElement)
     this.watchStyleSheets(document.documentElement)
+    // Also discover declarative shadow roots and roots created through an API
+    // another script replaced after our drawing/root notifications were installed.
+    this.rootTimer = setInterval(() => this.discoverRoots(), 1000)
   }
 
   // Live pause / allow-list: stop reacting to the page so no new image gets
@@ -60,6 +78,15 @@ export class DOMWatcher implements IDOMWatcher {
     if (!this.watching) return
     this.watching = false
     this.observer.disconnect()
+    clearInterval(this.rootTimer)
+    for (const root of this.roots) {
+      root.removeEventListener(CANVAS_DRAWN, this.onCanvasDrawn, true)
+      for (const type of BACKGROUND_EVENTS) {
+        root.removeEventListener(type, this.onBackgroundInteraction, true)
+      }
+    }
+    this.roots.clear()
+    document.removeEventListener(SHADOW_ROOT_CREATED, this.onShadowRootCreated)
     // Every stylesheet gets its own observer, so a stop that left them running
     // would keep both the callbacks and the removed <style> elements alive.
     this.sheetObservers.forEach(observer => observer.disconnect())
@@ -89,7 +116,7 @@ export class DOMWatcher implements IDOMWatcher {
         if (mutation.target instanceof HTMLElement) this.backgroundFilter.checkElement(mutation.target)
         if (mutation.addedNodes.length === 0) continue
 
-        this.findAndCheckAllMedia(mutation.target as Element)
+        this.findAndCheckAllMedia(mutation.target as ParentNode)
         // Backgrounds are registered per added subtree rather than by re-walking
         // the mutation target: a feed appending rows would otherwise re-walk the
         // whole feed on every row.
@@ -106,9 +133,9 @@ export class DOMWatcher implements IDOMWatcher {
 
   // A stylesheet can give an element on screen a background without touching an
   // attribute or an intersection, so its arrival is what prompts the recheck.
-  private watchStyleSheets (root: Element): void {
+  private watchStyleSheets (root: ParentNode): void {
     const sheets = [...root.querySelectorAll(STYLE_SHEET)]
-    if (root.matches(STYLE_SHEET)) sheets.push(root)
+    if (root instanceof Element && root.matches(STYLE_SHEET)) sheets.push(root)
     if (sheets.length === 0) return
 
     this.backgroundFilter.recheckVisible()
@@ -151,75 +178,147 @@ export class DOMWatcher implements IDOMWatcher {
     return element.matches(STYLE_SHEET) || element.querySelector(STYLE_SHEET) !== null
   }
 
-  private findAndCheckAllMedia (element: Element): void {
-    const images = element.getElementsByTagName('img')
-    for (let i = 0; i < images.length; i++) {
-      this.imageFilter.analyzeImage(images[i], false)
-    }
-
-    const videos = element.getElementsByTagName('video')
-    for (let i = 0; i < videos.length; i++) {
-      this.videoFilter.analyzeVideo(videos[i], false)
+  private findAndCheckAllMedia (root: ParentNode): void {
+    for (const current of mediaRoots(root)) {
+      if (current instanceof ShadowRoot) this.watchRoot(current)
+      const elements = [...current.querySelectorAll(MEDIA_SELECTOR)]
+      if (current instanceof Element && current.matches(MEDIA_SELECTOR)) elements.unshift(current)
+      for (const element of elements) {
+        if (element instanceof HTMLVideoElement) {
+          this.videoFilter.analyzeVideo(element, false)
+        } else if (element instanceof HTMLCanvasElement) {
+          this.canvasFilter.observe(element)
+        } else {
+          this.imageFilter.analyzeImage(element as ImageElement)
+        }
+      }
     }
   }
 
+  private watchRoot (root: ShadowRoot): void {
+    if (this.roots.has(root)) return
+    this.roots.add(root)
+    injectPendingHide(root)
+    root.addEventListener(CANVAS_DRAWN, this.onCanvasDrawn, true)
+    this.watchBackgroundInteractions(root)
+    this.observer.observe(root, DOMWatcher.getConfig())
+    for (const child of root.children) this.backgroundFilter.observe(child)
+    this.watchStyleSheets(root)
+  }
+
+  private discoverRoots (): void {
+    if (document.visibilityState !== 'visible') return
+    for (const root of mediaRoots()) {
+      if (root instanceof ShadowRoot && !this.roots.has(root)) this.findAndCheckAllMedia(root)
+    }
+    const detached = [...this.roots].filter(root => root instanceof ShadowRoot && !root.host.isConnected)
+    if (detached.length === 0) return
+    for (const root of detached) this.roots.delete(root)
+    this.observer.disconnect()
+    for (const root of this.roots) this.observer.observe(root, DOMWatcher.getConfig())
+  }
+
+  // The page world sends the host element; a closed root is resolved here rather
+  // than handed out where any script on the page could pick it up.
+  private readonly onShadowRootCreated = (event: Event): void => {
+    if (!this.watching) return
+    const host: unknown = (event as CustomEvent).detail
+    if (!(host instanceof Element)) return
+    const root = shadowRootOf(host)
+    if (root !== null) this.findAndCheckAllMedia(root)
+  }
+
+  private readonly onCanvasDrawn = (event: Event): void => {
+    if (!this.watching) return
+    const canvas = event.composedPath()[0]
+    if (canvas instanceof HTMLCanvasElement && event.currentTarget === canvas.getRootNode()) {
+      this.canvasFilter.observe(canvas, true)
+    }
+  }
+
+  // Hover and focus can change CSS without changing the DOM. Listen inside each
+  // shadow root too: interactions between its children may not leave that root.
+  private watchBackgroundInteractions (root: MediaRoot): void {
+    for (const type of BACKGROUND_EVENTS) {
+      root.addEventListener(type, this.onBackgroundInteraction, true)
+    }
+  }
+
+  private readonly onBackgroundInteraction = (): void => {
+    if (this.watching) this.backgroundFilter.recheckVisible()
+  }
+
+  // Five kinds of element can be affected by one attribute change, and an
+  // element can be more than one of them: a canvas carries its own background,
+  // an <img> can too. Each check decides for itself whether it applies.
   private checkAttributeMutation (mutation: MutationRecord): void {
     const node = mutation.target
+    const attribute = mutation.attributeName
+
+    if (node instanceof SVGElement && node.localName === 'image') {
+      this.checkImageElement(node as SVGImageElement, attribute)
+      return
+    }
     if (!(node instanceof HTMLElement)) return
 
-    // A class, id or hidden change can bring in a rule carrying a background
-    // image; a style change can set one directly. An <img> can carry one too, so
-    // this runs for images as well as for everything else.
-    if (mutation.attributeName === 'style') {
-      this.backgroundFilter.checkStyleMutation(node)
-    } else if (mutation.attributeName !== 'src' && mutation.attributeName !== 'poster') {
-      this.backgroundFilter.checkElement(node)
-    }
+    if (node instanceof HTMLCanvasElement) this.checkCanvas(node, attribute)
+    if (node instanceof HTMLSourceElement) this.checkPictureSource(node)
+    this.checkBackground(node, attribute)
 
-    if (node.nodeName === 'IMG') {
-      const image = node as HTMLImageElement
-      // A style change is the page overwriting our effect (see checkStyleMutation),
-      // not a new image to classify.
-      if (mutation.attributeName === 'style') {
-        this.imageFilter.checkStyleMutation(image)
-        return
-      }
+    if (node instanceof HTMLImageElement) this.checkImageElement(node, attribute)
+    else if (node instanceof HTMLVideoElement) this.checkVideo(node, attribute)
+  }
 
-      this.imageFilter.analyzeImage(image, mutation.attributeName === 'src')
-      return
-    }
+  // A style change is the page overwriting the effect we applied, not a new
+  // image to classify.
+  private checkImageElement (image: ImageElement, attribute: string | null): void {
+    if (attribute === 'style') this.imageFilter.checkStyleMutation(image)
+    else this.imageFilter.analyzeImage(image)
+  }
 
-    if (node.nodeName !== 'VIDEO') return
+  private checkCanvas (canvas: HTMLCanvasElement, attribute: string | null): void {
+    if (attribute === 'style') this.canvasFilter.checkStyleMutation(canvas)
+    else this.canvasFilter.observe(canvas)
+  }
 
-    const video = node as HTMLVideoElement
-    if (mutation.attributeName === 'style') {
-      this.videoFilter.checkStyleMutation(video)
-      return
-    }
+  // The <img> is what renders; a <source> only changes what it selects.
+  private checkPictureSource (source: HTMLSourceElement): void {
+    if (!(source.parentElement instanceof HTMLPictureElement)) return
+    const image = source.parentElement.querySelector('img')
+    if (image !== null) this.imageFilter.analyzeImage(image)
+  }
 
-    // A src swap fires loadstart, which VideoFilter already treats as new media;
-    // a poster swap fires nothing, so it has to come from here. It replaces the
-    // preview, not the footage, and so is not a media change.
-    if (mutation.attributeName === 'poster') {
-      this.videoFilter.checkPoster(video)
-      return
-    }
+  // A class, id or hidden change can bring in a rule carrying a background
+  // image; a style change can set one directly.
+  private checkBackground (element: HTMLElement, attribute: string | null): void {
+    if (attribute === 'style') this.backgroundFilter.checkStyleMutation(element)
+    else if (attribute !== 'src' && attribute !== 'poster') this.backgroundFilter.checkElement(element)
+  }
 
-    this.videoFilter.analyzeVideo(video, false)
+  // A src swap fires loadstart, which VideoFilter already treats as new media; a
+  // poster swap fires nothing, so it has to come from here. It replaces the
+  // preview, not the footage, and so is not a media change.
+  private checkVideo (video: HTMLVideoElement, attribute: string | null): void {
+    if (attribute === 'style') this.videoFilter.checkStyleMutation(video)
+    else if (attribute === 'poster') this.videoFilter.checkPoster(video)
+    else this.videoFilter.analyzeVideo(video, false)
   }
 
   // Backgrounds selected through other attributes, through CSSOM insertRule, or
-  // through adopted stylesheets and shadow roots are not covered: watching every
-  // attribute would re-read the visible set on any page that animates one. Nor
-  // are selectors that reach outside the changed element's parent, :has() above
-  // all, for the same reason: a mutation there rechecks that subtree only.
+  // through adopted stylesheets are not covered: watching every attribute would
+  // re-read the visible set on any page that animates one. Nor are selectors that
+  // reach outside the changed element's parent, :has() above all, for the same
+  // reason: a mutation there rechecks that subtree only.
   private static getConfig (): MutationObserverInit {
     return {
       characterData: false,
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ['src', 'style', 'poster', 'class', 'id', 'hidden']
+      attributeFilter: [
+        'src', 'srcset', 'sizes', 'href', 'xlink:href', 'media', 'type',
+        'width', 'height', 'style', 'poster', 'class', 'id', 'hidden'
+      ]
     }
   }
 }

--- a/src/content/DOMWatcher/DOMWatcher.ts
+++ b/src/content/DOMWatcher/DOMWatcher.ts
@@ -13,6 +13,11 @@ import { injectPendingHide } from './pendingStyle'
 const STYLE_SHEET = 'link[rel~="stylesheet"], style'
 const MEDIA_SELECTOR = 'img,video,canvas,svg image'
 const BACKGROUND_EVENTS = ['pointerover', 'pointerout', 'focusin', 'focusout']
+// The root sweep visits every element and asks Chrome for a shadow root on each,
+// which on a large page costs tens of milliseconds. Most seconds have no new
+// roots to find, so it runs when the document has changed, and once every few
+// seconds regardless for a root that appeared without a mutation we saw.
+const SWEEPS_BETWEEN_FULL = 5
 
 export type IDOMWatcher = {
   watch: () => void
@@ -26,6 +31,8 @@ export class DOMWatcher implements IDOMWatcher {
   private readonly backgroundFilter: IBackgroundImageFilter
   private readonly canvasFilter: ICanvasFilter
   private readonly roots = new Set<MediaRoot>()
+  private rootsDirty = true
+  private sweeps = 0
   private rootTimer: ReturnType<typeof setInterval> | undefined
   private sheetObservers: Map<Element, MutationObserver>
   private sheetLoads: AbortController
@@ -100,6 +107,7 @@ export class DOMWatcher implements IDOMWatcher {
     for (let i = 0; i < mutationsList.length; i++) {
       const mutation = mutationsList[i]
       if (mutation.type === 'childList') {
+        this.rootsDirty = true
         // A removed subtree has to give up its override and its pending request,
         // and a stale registration would keep the element alive with the page.
         mutation.removedNodes.forEach(node => {
@@ -208,6 +216,8 @@ export class DOMWatcher implements IDOMWatcher {
 
   private discoverRoots (): void {
     if (document.visibilityState !== 'visible') return
+    if (!this.rootsDirty && ++this.sweeps % SWEEPS_BETWEEN_FULL !== 0) return
+    this.rootsDirty = false
     for (const root of mediaRoots()) {
       if (root instanceof ShadowRoot && !this.roots.has(root)) this.findAndCheckAllMedia(root)
     }

--- a/src/content/DOMWatcher/pendingStyle.ts
+++ b/src/content/DOMWatcher/pendingStyle.ts
@@ -1,0 +1,52 @@
+export const HIDE_STYLE_ID = 'nsfw-filter-pending-hide'
+
+// Each shadow tree has its own style scope. Keep these rules identical in every
+// root; a document stylesheet cannot protect media inside a web component.
+// BackgroundImageFilter visits HTML elements, so its pending rules must too.
+export const PENDING_HIDE_RULES = `
+    @namespace html "http://www.w3.org/1999/xhtml";
+    @layer nsfw-filter {
+      img:not([data-nsfw-filter-status]),
+      video:not([data-nsfw-filter-status]),
+      canvas:not([data-nsfw-filter-status]),
+      svg image:not([data-nsfw-filter-status]) {
+        visibility: var(--nsfw-filter-pending-visibility, visible) !important;
+      }
+      /* The document root has no parent to query; its stylesheet is removed on pause. */
+      html|*:root:not([data-nsfw-filter-background-status]),
+      html|*:root:not([data-nsfw-filter-before-status])::before,
+      html|*:root:not([data-nsfw-filter-after-status])::after {
+        background-image: none !important;
+      }
+      /* Disable the rule entirely so an inactive shadow guard preserves page styles. */
+      @container style(--nsfw-filter-pending-background: none) {
+        html|*:not([data-nsfw-filter-background-status]),
+        html|*:not([data-nsfw-filter-before-status])::before,
+        html|*:not([data-nsfw-filter-after-status])::after {
+          background-image: none !important;
+        }
+      }
+      [data-nsfw-filter-before-hidden]::before,
+      [data-nsfw-filter-after-hidden]::after {
+        background-image: none !important;
+        visibility: hidden !important;
+      }
+    }
+  `
+
+export const injectPendingHide = (root: Document | ShadowRoot): void => {
+  if (root.querySelector(`#${HIDE_STYLE_ID}`) !== null) return
+  const style = document.createElement('style')
+  style.id = HIDE_STYLE_ID
+  // The inherited switch also reaches detached shadow roots when they are added
+  // later. Removing the document rule disables their pending hide too.
+  style.textContent = root instanceof Document
+    ? `${PENDING_HIDE_RULES}
+      :root {
+        --nsfw-filter-pending-visibility: hidden;
+        --nsfw-filter-pending-background: none;
+      }`
+    : PENDING_HIDE_RULES
+  if (root instanceof Document) root.documentElement.prepend(style)
+  else root.prepend(style)
+}

--- a/src/content/DOMWatcher/pendingStyle.ts
+++ b/src/content/DOMWatcher/pendingStyle.ts
@@ -6,11 +6,17 @@ export const HIDE_STYLE_ID = 'nsfw-filter-pending-hide'
 export const PENDING_HIDE_RULES = `
     @namespace html "http://www.w3.org/1999/xhtml";
     @layer nsfw-filter {
-      img:not([data-nsfw-filter-status]),
-      video:not([data-nsfw-filter-status]),
-      canvas:not([data-nsfw-filter-status]),
-      svg image:not([data-nsfw-filter-status]) {
-        visibility: var(--nsfw-filter-pending-visibility, revert-layer) !important;
+      /* Gated on the switch rather than a var() fallback: a CSS-wide keyword
+         substituted through var() is invalid at computed-value time, and
+         visibility then inherits, which showed media the page had hidden.
+         With the switch absent this rule does not apply at all. */
+      @container style(--nsfw-filter-pending-visibility: hidden) {
+        img:not([data-nsfw-filter-status]),
+        video:not([data-nsfw-filter-status]),
+        canvas:not([data-nsfw-filter-status]),
+        svg image:not([data-nsfw-filter-status]) {
+          visibility: hidden !important;
+        }
       }
       /* The document root has no parent to query; its stylesheet is removed on pause. */
       html|*:root:not([data-nsfw-filter-background-status]),

--- a/src/content/DOMWatcher/pendingStyle.ts
+++ b/src/content/DOMWatcher/pendingStyle.ts
@@ -10,7 +10,7 @@ export const PENDING_HIDE_RULES = `
       video:not([data-nsfw-filter-status]),
       canvas:not([data-nsfw-filter-status]),
       svg image:not([data-nsfw-filter-status]) {
-        visibility: var(--nsfw-filter-pending-visibility, visible) !important;
+        visibility: var(--nsfw-filter-pending-visibility, revert-layer) !important;
       }
       /* The document root has no parent to query; its stylesheet is removed on pause. */
       html|*:root:not([data-nsfw-filter-background-status]),

--- a/src/content/Filter/BackgroundImageFilter.ts
+++ b/src/content/Filter/BackgroundImageFilter.ts
@@ -2,7 +2,7 @@ import { PredictionRequest } from '../../utils/messages'
 import { mediaElements } from '../mediaRoots'
 
 import { backgroundImageUrls } from './backgroundImageValue'
-import { Filter, MIN_MEDIA_SIZE } from './Filter'
+import { Filter, MIN_MEDIA_SIZE, OFFSCREEN_MARGIN } from './Filter'
 
 export type IBackgroundImageFilter = {
   observe: (root: Element) => void
@@ -37,7 +37,6 @@ type BackgroundState = {
   } | null
 }
 
-const OFFSCREEN_MARGIN = '300px'
 // Past this many dirty roots, testing every visible element against each of them
 // costs more than simply re-reading the visible set.
 const DIRTY_ROOT_LIMIT = 8

--- a/src/content/Filter/BackgroundImageFilter.ts
+++ b/src/content/Filter/BackgroundImageFilter.ts
@@ -1,7 +1,8 @@
 import { PredictionRequest } from '../../utils/messages'
+import { mediaElements } from '../mediaRoots'
 
 import { backgroundImageUrls } from './backgroundImageValue'
-import { Filter } from './Filter'
+import { Filter, MIN_MEDIA_SIZE } from './Filter'
 
 export type IBackgroundImageFilter = {
   observe: (root: Element) => void
@@ -36,7 +37,6 @@ type BackgroundState = {
   } | null
 }
 
-const MIN_ELEMENT_SIZE = 41
 const OFFSCREEN_MARGIN = '300px'
 // Past this many dirty roots, testing every visible element against each of them
 // costs more than simply re-reading the visible set.
@@ -45,6 +45,15 @@ const DIRTY_ROOT_LIMIT = 8
 // catch a breakpoint being crossed.
 const RESIZE_INTERVAL = 250
 // Elements that never paint a background, so walking into them is wasted work.
+// Every style write we make reaches the observer as its own mutation record, and
+// checkStyleMutation counts them off one by one. The writes go through this so a
+// caller cannot perform one without it being counted.
+type StyleWriter = {
+  set: (property: string, value: string, priority: string) => void
+  remove: (property: string) => void
+  dropAttribute: () => void
+}
+
 const SKIPPED = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'TITLE', 'HEAD', 'TEMPLATE', 'NOSCRIPT', 'BR'])
 
 export class BackgroundImageFilter extends Filter implements IBackgroundImageFilter {
@@ -58,8 +67,21 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   private resizeTimer: ReturnType<typeof setTimeout> | undefined
   private active: boolean
 
-  constructor () {
+  private readonly pseudoFilters: BackgroundImageFilter[]
+  private readonly statusKey: string
+  private readonly statusAttribute: string
+  private readonly hiddenAttribute: string
+
+  constructor (private readonly pseudo: 'before' | 'after' | null = null) {
     super()
+    this.pseudoFilters = pseudo === null
+      ? [new BackgroundImageFilter('before'), new BackgroundImageFilter('after')]
+      : []
+    this.statusKey = pseudo === null
+      ? 'nsfwFilterBackgroundStatus'
+      : `nsfwFilter${pseudo === 'before' ? 'Before' : 'After'}Status`
+    this.statusAttribute = `data-nsfw-filter-${pseudo ?? 'background'}-status`
+    this.hiddenAttribute = `data-nsfw-filter-${pseudo}-hidden`
     this.states = new WeakMap()
     this.visible = new Set()
     this.writes = new WeakMap()
@@ -87,6 +109,7 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   // asking every element on load costs a full style resolution. Registration is
   // cheap; the question is asked when the element comes near the viewport.
   public observe (root: Element): void {
+    this.eachPseudo(filter => filter.observe(root))
     if (!this.active) return
 
     this.walk(root, element => {
@@ -101,6 +124,7 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   // A removed subtree keeps its override and its pending request otherwise, which
   // leaves the background missing for good if the element comes back.
   public release (root: Element): void {
+    this.eachPseudo(filter => filter.release(root))
     this.walk(root, element => {
       if (element.isConnected) {
         // Moved rather than removed: keep it hidden and force a fresh verdict. Its
@@ -118,13 +142,14 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
       if (!this.states.has(element)) return
       this.restore(element)
       this.states.delete(element)
-      delete element.dataset.nsfwFilterBackgroundStatus
+      delete element.dataset[this.statusKey]
     })
   }
 
   // A class change can swap the background of the element itself or of anything
   // under it, and a rule that now matches produces no new intersection.
   public checkElement (element: HTMLElement): void {
+    this.eachPseudo(filter => filter.checkElement(element))
     this.markDirty(element)
   }
 
@@ -133,18 +158,20 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   // are counted off one by one: an intact override proves nothing, and a page that
   // writes in reaction to ours must not be swallowed along with it.
   public checkStyleMutation (element: HTMLElement): void {
+    this.eachPseudo(filter => filter.checkStyleMutation(element))
     const ours = this.writes.get(element) ?? 0
     if (ours > 0) {
       this.writes.set(element, ours - 1)
       return
     }
 
-    this.checkElement(element)
+    this.markDirty(element)
   }
 
   // A stylesheet arriving late changes no attribute and triggers no intersection,
   // so nothing else would ask about the backgrounds it brings.
   public recheckVisible (): void {
+    this.eachPseudo(filter => filter.recheckVisible())
     if (!this.active) return
     this.allDirty = true
     this.schedule()
@@ -156,22 +183,25 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   public applyEffectToBlocked (): void {}
 
   public revealAll (): void {
+    this.eachPseudo(filter => filter.revealAll())
     this.filtered().forEach(element => {
       this.restore(element)
       this.states.delete(element)
-      delete element.dataset.nsfwFilterBackgroundStatus
+      delete element.dataset[this.statusKey]
     })
   }
 
   // Resuming produces no new intersection for targets already registered, so what
   // is on screen has to be re-read here or it stays revealed.
   public start (): void {
+    this.eachPseudo(filter => filter.start())
     this.active = true
     this.recheckVisible()
   }
 
   // Live pause or allow-list. Restoring what we removed is revealAll's job.
   public stop (): void {
+    this.eachPseudo(filter => filter.stop())
     this.active = false
     this.dirty.clear()
     this.allDirty = false
@@ -203,10 +233,10 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   private schedule (): void {
     if (this.scheduled) return
     this.scheduled = true
-    setTimeout(() => {
+    queueMicrotask(() => {
       this.scheduled = false
       this.flush()
-    }, 0)
+    })
   }
 
   private flush (): void {
@@ -223,7 +253,7 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
 
     const done = new Set<HTMLElement>()
     for (const root of roots) {
-      if (!this.visible.has(root) && root.dataset.nsfwFilterBackgroundStatus === undefined) continue
+      if (!this.visible.has(root) && root.dataset[this.statusKey] === undefined) continue
       done.add(root)
       this.analyze(root)
     }
@@ -257,35 +287,46 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
     // box they happen to have.
     const { width, height } = element.getBoundingClientRect()
     const canvas = element === document.body || element === document.documentElement
-    if (!canvas && (width <= MIN_ELEMENT_SIZE || height <= MIN_ELEMENT_SIZE)) return
+    if (this.pseudo === null && !canvas && (width <= MIN_MEDIA_SIZE || height <= MIN_MEDIA_SIZE)) {
+      if (width > 0 && height > 0 && element.dataset[this.statusKey] === undefined) {
+        element.dataset[this.statusKey] = 'sfw'
+      }
+      return
+    }
 
     const state = this.states.get(element)
     // Our own override masks the author's value, so the page's current background
     // has to be read with it lifted. Both writes land in this task, before paint.
     if (state !== undefined) this.restore(element)
 
-    const urls = backgroundImageUrls(getComputedStyle(element).backgroundImage)
+    // Lift the pending stylesheet only while reading the author's background.
+    // A real image is hidden again below in the same task, before paint.
+    if (element.dataset[this.statusKey] === undefined) {
+      element.dataset[this.statusKey] = 'processing'
+    }
+
+    const computed = this.pseudo === null
+      ? getComputedStyle(element)
+      : getComputedStyle(element, `::${this.pseudo}`)
+    const urls = backgroundImageUrls(computed.backgroundImage)
     const key = urls.join(' ')
     if (urls.length === 0) {
-      if (state !== undefined) {
-        this.states.delete(element)
-        delete element.dataset.nsfwFilterBackgroundStatus
-      }
+      this.states.delete(element)
+      if (element.dataset[this.statusKey] !== 'sfw') element.dataset[this.statusKey] = 'sfw'
       return
     }
 
-    const status = element.dataset.nsfwFilterBackgroundStatus
-    if (state !== undefined && state.key === key && status !== undefined && (status !== 'processing' || state.pending)) {
-      // Same background as the verdict we already hold, or as the one still in
-      // flight; put the effect back if it was a block, since restore() lifted it.
-      if (status !== 'sfw') this.hide(element, state)
+    const status = element.dataset[this.statusKey]
+    if (this.alreadyJudging(state, key, status)) {
+      // Put the effect back if it was a block, since restore() lifted it.
+      if (status !== 'sfw') this.hide(element, state as BackgroundState)
       return
     }
 
     const generation = (state?.generation ?? 0) + 1
     const next: BackgroundState = { generation, key, pending: true, inline: null }
     this.states.set(element, next)
-    element.dataset.nsfwFilterBackgroundStatus = 'processing'
+    element.dataset[this.statusKey] = 'processing'
     this.hide(element, next)
 
     void this.classify(element, next, urls)
@@ -293,18 +334,43 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
 
   // One unsafe layer condemns the stack: the layers are positioned against each
   // other, and dropping only one leaves the rest misaligned over a gap.
+  // The verdict we hold, or the one still in flight, is for exactly this stack of
+  // urls: there is nothing new to ask.
+  // Backgrounds keep their verdict under their own attribute, one per pseudo, so
+  // the inherited status checks have to look there rather than at the element's
+  // media status.
+  protected statusOf (element: HTMLElement): string | undefined {
+    return element.dataset[this.statusKey]
+  }
+
+  // The ::before and ::after instances are driven from here so every entry point
+  // reaches all three. A public method that forgets this line filters the
+  // element's own background and silently leaves its pseudo-elements alone.
+  private eachPseudo (apply: (filter: BackgroundImageFilter) => void): void {
+    for (const filter of this.pseudoFilters) apply(filter)
+  }
+
+  private alreadyJudging (
+    state: BackgroundState | undefined, key: string, status: string | undefined
+  ): boolean {
+    if (state?.key !== key || status === undefined) return false
+    return status !== 'processing' || state.pending
+  }
+
   private async classify (element: HTMLElement, state: BackgroundState, urls: string[]): Promise<void> {
     let blocked = false
+    let unavailable = false
 
     for (const url of urls) {
       try {
-        const { result } = await this.requestToAnalyzeImage(new PredictionRequest(url))
+        const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(url))
+        if (error !== undefined) unavailable = true
         if (result) {
           blocked = true
           break
         }
       } catch {
-        // Fail open: an unanswered background is the page's own, not ours to keep.
+        unavailable = true
       }
     }
 
@@ -313,17 +379,21 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
 
     if (blocked) {
       this.blockedItems++
-      element.dataset.nsfwFilterBackgroundStatus = 'nsfw'
+      element.dataset[this.statusKey] = 'nsfw'
       return
     }
 
-    element.dataset.nsfwFilterBackgroundStatus = 'sfw'
-    this.restore(element)
+    element.dataset[this.statusKey] = unavailable ? 'unavailable' : 'sfw'
+    if (!unavailable) this.restore(element)
   }
 
   // Removing the image is the only effect that leaves the element alone: blur or
   // visibility on the element would take its text and children with it.
   private hide (element: HTMLElement, state: BackgroundState): void {
+    if (this.pseudo !== null) {
+      element.setAttribute(this.hiddenAttribute, '')
+      return
+    }
     if (state.inline === null) {
       const value = element.style.getPropertyValue('background-image')
       // `background: var(--photo)` has no readable longhand, and the override
@@ -343,10 +413,7 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
       }
     }
 
-    this.write(element, () => {
-      element.style.setProperty('background-image', 'none', 'important')
-      return 1
-    })
+    this.write(element, style => style.set('background-image', 'none', 'important'))
   }
 
   private overridden (element: HTMLElement): boolean {
@@ -355,6 +422,10 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   }
 
   private restore (element: HTMLElement): void {
+    if (this.pseudo !== null) {
+      element.removeAttribute(this.hiddenAttribute)
+      return
+    }
     const state = this.states.get(element)
     if (state?.inline == null) return
 
@@ -364,24 +435,13 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
     // newer than what we saved.
     if (!this.overridden(element)) return
 
-    this.write(element, () => {
-      element.style.removeProperty('background-image')
-      let mutations = 1
+    this.write(element, style => {
+      style.remove('background-image')
 
-      if (shorthand !== null) {
-        element.style.setProperty('background', shorthand.value, shorthand.priority)
-        mutations++
-      } else if (value !== '') {
-        element.style.setProperty('background-image', value, priority)
-        mutations++
-      }
+      if (shorthand !== null) style.set('background', shorthand.value, shorthand.priority)
+      else if (value !== '') style.set('background-image', value, priority)
 
-      if (!attribute && element.style.length === 0) {
-        element.removeAttribute('style')
-        mutations++
-      }
-
-      return mutations
+      if (!attribute && element.style.length === 0) style.dropAttribute()
     })
   }
 
@@ -390,13 +450,27 @@ export class BackgroundImageFilter extends Filter implements IBackgroundImageFil
   // made while nothing is observing would otherwise eat a later page mutation.
   // One write can touch the declaration more than once, and every touch is a
   // record of its own: crediting one of them leaves us chasing our own writes.
-  private write (element: HTMLElement, apply: () => number): void {
-    const made = apply()
+  private write (element: HTMLElement, apply: (style: StyleWriter) => void): void {
+    let made = 0
+    apply({
+      set: (property, value, priority) => {
+        element.style.setProperty(property, value, priority)
+        made++
+      },
+      remove: (property) => {
+        element.style.removeProperty(property)
+        made++
+      },
+      dropAttribute: () => {
+        element.removeAttribute('style')
+        made++
+      }
+    })
     this.writes.set(element, (this.writes.get(element) ?? 0) + made)
     queueMicrotask(() => this.writes.delete(element))
   }
 
   private filtered (): HTMLElement[] {
-    return [...document.querySelectorAll<HTMLElement>('[data-nsfw-filter-background-status]')]
+    return mediaElements<HTMLElement>(`[${this.statusAttribute}]`)
   }
 }

--- a/src/content/Filter/CanvasFilter.ts
+++ b/src/content/Filter/CanvasFilter.ts
@@ -1,0 +1,180 @@
+import { PredictionRequest } from '../../utils/messages'
+import { mediaElements } from '../mediaRoots'
+
+import { Filter } from './Filter'
+
+export type ICanvasFilter = {
+  observe: (canvas: HTMLCanvasElement, drawn?: boolean) => void
+  revealCanvas: (canvas: HTMLCanvasElement) => void
+  checkStyleMutation: (canvas: HTMLCanvasElement) => void
+  applyEffectToBlocked: () => void
+  revealAll: () => void
+  start: () => void
+  stop: () => void
+}
+
+type CanvasState = {
+  epoch: number
+  pixels: string
+  pending: boolean
+  overridden: boolean
+}
+
+const FRAME_SIZE = 224
+const SAMPLE_INTERVAL = 1000
+
+// Drawing notifications catch changes before paint. Polling also covers drawings
+// made outside the page's context, such as an OffscreenCanvas in a worker.
+export class CanvasFilter extends Filter implements ICanvasFilter {
+  private readonly states = new WeakMap<HTMLCanvasElement, CanvasState>()
+  private readonly visible = new Set<HTMLCanvasElement>()
+  private readonly viewport: IntersectionObserver
+  private timer: ReturnType<typeof setInterval> | undefined
+  private active = true
+  private epoch = 0
+
+  constructor () {
+    super()
+    this.viewport = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const canvas = entry.target as HTMLCanvasElement
+        if (entry.isIntersecting) this.visible.add(canvas)
+        else this.visible.delete(canvas)
+      }
+      this.sampleVisible()
+    })
+  }
+
+  public observe (canvas: HTMLCanvasElement, drawn = false): void {
+    if (!this.active) return
+    if (this.states.get(canvas)?.epoch !== this.epoch) {
+      this.states.set(canvas, { epoch: this.epoch, pixels: '', pending: false, overridden: false })
+      canvas.dataset.nsfwFilterStatus = 'processing'
+      this.hideElement(canvas)
+    }
+    this.viewport.observe(canvas)
+    if (drawn) this.sampleCanvas(canvas)
+    if (this.timer === undefined) {
+      this.timer = setInterval(() => this.sampleVisible(), SAMPLE_INTERVAL)
+    }
+  }
+
+  public revealCanvas (canvas: HTMLCanvasElement): void {
+    const state = this.states.get(canvas)
+    if (state !== undefined) state.overridden = true
+    this.revealElement(canvas)
+    canvas.dataset.nsfwFilterStatus = 'sfw'
+  }
+
+  public applyEffectToBlocked (): void {
+    for (const canvas of mediaElements<HTMLCanvasElement>('canvas[data-nsfw-filter-status]')) {
+      this.checkStyleMutation(canvas)
+    }
+  }
+
+  public start (): void {
+    this.active = true
+  }
+
+  public stop (): void {
+    this.active = false
+    this.epoch++
+    clearInterval(this.timer)
+    this.timer = undefined
+    this.viewport.disconnect()
+    this.visible.clear()
+  }
+
+  public revealAll (): void {
+    for (const canvas of mediaElements<HTMLCanvasElement>('canvas[data-nsfw-filter-status]')) {
+      this.revealElement(canvas)
+      this.states.delete(canvas)
+      delete canvas.dataset.nsfwFilterStatus
+    }
+  }
+
+  private sampleVisible (): void {
+    if (!this.active || document.visibilityState !== 'visible') return
+    for (const canvas of this.visible) {
+      if (!canvas.isConnected) {
+        this.visible.delete(canvas)
+        this.viewport.unobserve(canvas)
+        this.states.delete(canvas)
+        continue
+      }
+      this.sampleCanvas(canvas)
+    }
+  }
+
+  private sampleCanvas (canvas: HTMLCanvasElement): void {
+    const state = this.states.get(canvas)
+    if (state === undefined || state.pending || state.overridden) return
+    if (this.isBlocked(canvas)) return
+    void this.sample(canvas, state)
+  }
+
+  private async sample (canvas: HTMLCanvasElement, state: CanvasState): Promise<void> {
+    const epoch = this.epoch
+    state.pending = true
+    try {
+      if (this.belowMinSize(canvas.clientWidth, canvas.clientHeight)) {
+        canvas.dataset.nsfwFilterStatus = 'sfw'
+        this.revealElement(canvas)
+        return
+      }
+      const copy = document.createElement('canvas')
+      copy.width = copy.height = FRAME_SIZE
+      const context = copy.getContext('2d')
+      if (context === null) throw new Error('Canvas pixels unavailable')
+      const readPixels = (): string => {
+        context.clearRect(0, 0, FRAME_SIZE, FRAME_SIZE)
+        context.drawImage(canvas, 0, 0, FRAME_SIZE, FRAME_SIZE)
+        return copy.toDataURL('image/png')
+      }
+      const pixels = readPixels()
+      if (pixels === state.pixels) return
+      state.pixels = pixels
+      canvas.dataset.nsfwFilterStatus = 'processing'
+      this.hideElement(canvas)
+      // Nothing drawn yet, or cleared: there is nothing to show and nothing to
+      // judge. Settling it keeps the canvas out of a pending state it can only
+      // leave by being drawn again.
+      if (!this.hasVisiblePixels(context)) {
+        canvas.dataset.nsfwFilterStatus = 'sfw'
+        this.revealElement(canvas)
+        return
+      }
+      const key = `nsfw-filter-canvas:${crypto.randomUUID()}`
+      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(key, pixels))
+      if (epoch !== this.epoch || state.overridden) return
+      if (error !== undefined) throw new Error(error)
+      // Drawing can continue while the model works. A safe verdict must not
+      // reveal different pixels; the next sample will inspect those instead.
+      if (!result && readPixels() !== pixels) {
+        state.pixels = ''
+        return
+      }
+      canvas.dataset.nsfwFilterStatus = result ? 'nsfw' : 'sfw'
+      if (result) {
+        this.blockedItems++
+        this.applyEffect(canvas)
+      } else {
+        this.revealElement(canvas)
+      }
+    } catch {
+      if (epoch !== this.epoch || state.overridden) return
+      canvas.dataset.nsfwFilterStatus = 'unavailable'
+      this.applyEffect(canvas)
+    } finally {
+      state.pending = false
+    }
+  }
+
+  private hasVisiblePixels (context: CanvasRenderingContext2D): boolean {
+    const rgba = context.getImageData(0, 0, FRAME_SIZE, FRAME_SIZE).data
+    for (let alpha = 3; alpha < rgba.length; alpha += 4) {
+      if (rgba[alpha] !== 0) return true
+    }
+    return false
+  }
+}

--- a/src/content/Filter/CanvasFilter.ts
+++ b/src/content/Filter/CanvasFilter.ts
@@ -23,6 +23,13 @@ type CanvasState = {
 const FRAME_SIZE = 224
 const SAMPLE_INTERVAL = 1000
 
+// Snapshots are keyed, not addressed, and the background deduplicates by key
+// across every tab, so the key is scoped to this realm. randomUUID would do but
+// it is secure-context only, and an ordinary http page has to work too.
+const REALM = crypto.getRandomValues(new Uint32Array(2)).join('')
+let snapshots = 0
+const snapshotKey = (): string => `nsfw-filter-canvas:${REALM}-${++snapshots}`
+
 // Drawing notifications catch changes before paint. Polling also covers drawings
 // made outside the page's context, such as an OffscreenCanvas in a worker.
 export class CanvasFilter extends Filter implements ICanvasFilter {
@@ -144,8 +151,7 @@ export class CanvasFilter extends Filter implements ICanvasFilter {
         this.revealElement(canvas)
         return
       }
-      const key = `nsfw-filter-canvas:${crypto.randomUUID()}`
-      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(key, pixels))
+      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(snapshotKey(), pixels))
       if (epoch !== this.epoch || state.overridden) return
       if (error !== undefined) throw new Error(error)
       // Drawing can continue while the model works. A safe verdict must not

--- a/src/content/Filter/Filter.ts
+++ b/src/content/Filter/Filter.ts
@@ -18,6 +18,10 @@ const GRAYSCALE = 'grayscale(1)'
 // backgrounds and canvases all draw the line in the same place.
 export const MIN_MEDIA_SIZE = 41
 
+// How far outside the viewport media is still worth judging, so it is ready by
+// the time a scroll brings it in.
+export const OFFSCREEN_MARGIN = '300px'
+
 type FilterRequestWaiter = {
   resolve: (value: PredictionResponse) => void
   reject: (error: PredictionRequest) => void
@@ -169,6 +173,18 @@ export class Filter implements IFilter {
     })
   }
 
+  // The deadline is there to catch a pipeline that has stopped answering, not one
+  // that is merely busy. A reply is proof it is still working, so whatever is
+  // queued behind it starts its wait again: a page with more media than the model
+  // can judge inside one deadline would otherwise give up on the tail of it, and
+  // give up means blocked.
+  private _renewDeadlines (): void {
+    for (const [url, queued] of this.requestQueue) {
+      window.clearTimeout(queued.deadline)
+      queued.deadline = window.setTimeout(() => this._giveUp(url), ANALYSIS_DEADLINE)
+    }
+  }
+
   // Takes the pending entry off the queue and stops its timers. undefined means it
   // was already settled, which is how a reply that arrives too late is dropped.
   private _take (url: string): FilterRequestQueueValue | undefined {
@@ -214,6 +230,7 @@ export class Filter implements IFilter {
       const pending = this._takeFor(request)
       if (pending === undefined) return
 
+      this._renewDeadlines()
       for (const { resolve } of pending.waiters) resolve(response)
     })
   }

--- a/src/content/Filter/Filter.ts
+++ b/src/content/Filter/Filter.ts
@@ -5,6 +5,7 @@ type IFilter = {
 }
 
 export type FilterEffect = 'blur' | 'hide' | 'grayscale'
+export type FilterElement = HTMLElement | SVGElement
 
 export type FilterSettings = {
   filterEffect: FilterEffect
@@ -12,6 +13,10 @@ export type FilterSettings = {
 
 const BLUR = 'blur(25px)'
 const GRAYSCALE = 'grayscale(1)'
+
+// Icons, sprites and spacers: too small to be worth a round trip. Images,
+// backgrounds and canvases all draw the line in the same place.
+export const MIN_MEDIA_SIZE = 41
 
 type FilterRequestWaiter = {
   resolve: (value: PredictionResponse) => void
@@ -26,15 +31,15 @@ type FilterRequestQueueValue = {
 
 // An image stays hidden until its prediction settles, and nothing downstream is
 // guaranteed to answer: the service worker can be torn down mid-request, and an
-// offscreen document whose TensorFlow.js backend wedged never replies. Reveal the
-// image rather than leave it hidden for the life of the page.
+// offscreen document whose TensorFlow.js backend wedged never replies. Settle
+// with an error so callers can distinguish unavailable media from safe media.
 const ANALYSIS_DEADLINE = 60000
 
 export class Filter implements IFilter {
   protected blockedItems: number
   protected settings: FilterSettings
   private readonly requestQueue: Map<string, FilterRequestQueueValue>
-  private readonly hiddenByUs: WeakSet<HTMLElement>
+  private readonly hiddenByUs: WeakSet<FilterElement>
 
   constructor () {
     this.blockedItems = 0
@@ -51,47 +56,89 @@ export class Filter implements IFilter {
     this.settings = settings
   }
 
+  protected statusOf (element: FilterElement): string | undefined {
+    return element.dataset.nsfwFilterStatus
+  }
+
+  public checkStyleMutation (element: FilterElement): void {
+    const status = this.statusOf(element)
+    if (status === 'processing') {
+      if (!this.isHidden(element)) this.hideElement(element)
+      return
+    }
+    if (!this.isBlocked(element)) return
+    if (!this.isEffectApplied(element)) this.applyEffect(element)
+  }
+
   // `hidden` as well as the inline style: an image whose parent is BODY is
   // rendered by Chrome's document-level image viewer, which ignores visibility.
   // Track what we hid that way: the page can move the element out of BODY before
   // the verdict lands, and clearing `hidden` only for what is still a BODY child
   // would leave it hidden for good.
-  protected hideElement (element: HTMLElement): void {
+  protected hideElement (element: FilterElement): void {
     if (element instanceof HTMLImageElement && element.parentNode?.nodeName === 'BODY') {
       element.hidden = true
       this.hiddenByUs.add(element)
     }
-    element.style.visibility = 'hidden'
+    element.style.setProperty('visibility', 'hidden', 'important')
   }
 
-  protected revealElement (element: HTMLElement): void {
+  // Remove what we wrote rather than forcing `visible`: the page may have hidden
+  // this element for its own reasons, and a filter that is off should leave no
+  // declaration of ours behind.
+  protected revealElement (element: FilterElement): void {
     this.unsetHidden(element)
-    element.style.filter = ''
-    element.style.visibility = 'visible'
+    element.style.removeProperty('filter')
+    element.style.removeProperty('visibility')
   }
 
-  protected applyEffect (element: HTMLElement): void {
+  protected applyEffect (element: FilterElement): void {
     if (this.settings.filterEffect === 'hide') {
       this.hideElement(element)
       return
     }
 
-    element.style.filter = this.settings.filterEffect === 'blur' ? BLUR : GRAYSCALE
-    element.style.visibility = 'visible'
+    const effect = this.settings.filterEffect === 'blur' ? BLUR : GRAYSCALE
+    element.style.setProperty('filter', effect, 'important')
+    // Blur and grayscale show the element; lift a hide from an earlier verdict
+    // without overriding the page's own visibility.
+    element.style.removeProperty('visibility')
     this.unsetHidden(element)
   }
 
-  private unsetHidden (element: HTMLElement): void {
-    if (this.hiddenByUs.delete(element)) element.hidden = false
+  private unsetHidden (element: FilterElement): void {
+    if (this.hiddenByUs.delete(element) && element instanceof HTMLElement) element.hidden = false
   }
 
   // Match our exact value, not a substring: a site setting its own weak
   // `filter: blur(1px)` on a blocked element must still count as effect-gone so
   // we re-apply the full blur, not leave it barely obscured.
-  protected isEffectApplied (element: HTMLElement): boolean {
-    if (this.settings.filterEffect === 'blur') return element.style.filter === BLUR
-    if (this.settings.filterEffect === 'grayscale') return element.style.filter === GRAYSCALE
-    return element.style.visibility === 'hidden'
+  protected isEffectApplied (element: FilterElement): boolean {
+    if (this.settings.filterEffect === 'hide') return this.isHidden(element)
+    return this.hasImportant(element, 'filter', this.settings.filterEffect === 'blur' ? BLUR : GRAYSCALE)
+  }
+
+  protected isHidden (element: FilterElement): boolean {
+    return this.hasImportant(element, 'visibility', 'hidden')
+  }
+
+  // Blocked either way: one is a verdict, the other is our answer to media we
+  // could not read. Both wear the configured effect and neither is re-judged.
+  protected isBlocked (element: FilterElement): boolean {
+    const status = this.statusOf(element)
+    return status === 'nsfw' || status === 'unavailable'
+  }
+
+  // Zero means the element has no box yet, not that it is small: it is still a
+  // candidate, and clearing it here would show whatever it holds the moment the
+  // page gives it a size.
+  protected belowMinSize (width: number, height: number): boolean {
+    return width !== 0 && height !== 0 && (width <= MIN_MEDIA_SIZE || height <= MIN_MEDIA_SIZE)
+  }
+
+  private hasImportant (element: FilterElement, property: string, value: string): boolean {
+    return element.style.getPropertyValue(property) === value &&
+      element.style.getPropertyPriority(property) === 'important'
   }
 
   protected async requestToAnalyzeImage (request: PredictionRequest): Promise<PredictionResponse> {
@@ -151,7 +198,7 @@ export class Filter implements IFilter {
     const pending = this._take(url)
     if (pending === undefined) return
 
-    console.warn(`[NSFW-Filter] No verdict for ${url} after ${ANALYSIS_DEADLINE}ms, marked as visible`)
+    console.warn(`[NSFW-Filter] No verdict for ${url} after ${ANALYSIS_DEADLINE}ms, analysis unavailable`)
     for (const { resolve } of pending.waiters) {
       resolve(new PredictionResponse(false, url, 'Analysis timed out'))
     }
@@ -183,7 +230,7 @@ export class Filter implements IFilter {
       const pending = this._takeFor(request)
       if (pending === undefined) return
 
-      console.warn(`[NSFW-Filter] Background worker is down, marked as visible ${request.url}`)
+      console.warn(`[NSFW-Filter] Background worker is down, analysis unavailable ${request.url}`)
       for (const { resolve } of pending.waiters) {
         resolve(new PredictionResponse(false, request.url, 'Background worker doesn\'t working'))
       }

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -48,9 +48,10 @@ export class ImageFilter extends Filter implements IImageFilter {
     if (source !== previous) this.unhidden.delete(image)
     this.sources.set(image, source)
 
+    // Nothing to judge. An element whose source is cleared mid-flight has to be
+    // released, or it keeps a `processing` tag no reply will ever settle.
     if (source === '') {
-      this.revealElement(image)
-      delete image.dataset.nsfwFilterStatus
+      if (status === 'processing') this.showImage(image)
       return
     }
 

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -1,7 +1,7 @@
 import { PredictionRequest } from '../../utils/messages'
 import { mediaElements } from '../mediaRoots'
 
-import { Filter, FilterSettings } from './Filter'
+import { Filter, FilterSettings, OFFSCREEN_MARGIN } from './Filter'
 
 export type ImageElement = HTMLImageElement | SVGImageElement
 
@@ -25,6 +25,27 @@ export class ImageFilter extends Filter implements IImageFilter {
   private readonly sources = new WeakMap<ImageElement, string>()
   private readonly wired = new WeakSet<ImageElement>()
   private readonly smallImages = new WeakSet<ImageElement>()
+  private readonly viewport: IntersectionObserver
+  private readonly awaiting = new Set<ImageElement>()
+
+  constructor () {
+    super()
+    // Every filter shares one prediction chain, so asking about a whole page of
+    // images at once pushes the last of them past their deadline, where they
+    // settle as unavailable and are blocked. An image keeps its processing tag
+    // and stays hidden until it comes within range of the viewport.
+    this.viewport = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const image = entry.target as ImageElement
+        if (entry.isIntersecting) this.classify(image)
+        else if (!image.isConnected) {
+          // Gone from the page before it was ever reached: stop holding on to it.
+          this.viewport.unobserve(image)
+          this.awaiting.delete(image)
+        }
+      }
+    }, { rootMargin: OFFSCREEN_MARGIN })
+  }
 
   public revealImage (image: ImageElement): void {
     this.unhidden.add(image)
@@ -67,6 +88,25 @@ export class ImageFilter extends Filter implements IImageFilter {
     }
 
     this.smallImages.delete(image)
+    this.awaiting.add(image)
+
+    // A verdict already on the element is on screen, and whatever changed here
+    // makes it stale: take it down and ask again now. Waiting to be told the
+    // element is in view would leave the old verdict showing, which is what a
+    // seek preview swapping its source through one <img> does.
+    if (status !== undefined) this.classify(image)
+    // A first look waits instead, since observing reports what is in view. Until
+    // then it stays untagged, where the pending rule hides it without collapsing
+    // the box the observer needs: tagging hides it inline, and `hidden` on a BODY
+    // child removes that box.
+    else this.viewport.observe(image)
+  }
+
+  // Taking it out of the waiting set is what keeps one image from being asked
+  // about twice for the same change.
+  private classify (image: ImageElement): void {
+    if (!this.awaiting.delete(image)) return
+
     image.dataset.nsfwFilterStatus = 'processing'
     this.hideElement(image)
     void this._analyzeImage(image)
@@ -101,6 +141,8 @@ export class ImageFilter extends Filter implements IImageFilter {
   public stop (): void {
     this.active = false
     this.epoch++
+    this.viewport.disconnect()
+    this.awaiting.clear()
   }
 
   private sourceOf (image: ImageElement): string {

--- a/src/content/Filter/ImageFilter.ts
+++ b/src/content/Filter/ImageFilter.ts
@@ -1,145 +1,147 @@
 import { PredictionRequest } from '../../utils/messages'
+import { mediaElements } from '../mediaRoots'
 
 import { Filter, FilterSettings } from './Filter'
 
+export type ImageElement = HTMLImageElement | SVGImageElement
+
 export type IImageFilter = {
-  analyzeImage: (image: HTMLImageElement, srcAttribute: boolean) => void
+  analyzeImage: (image: ImageElement) => void
   setSettings: (settings: FilterSettings) => void
-  revealImage: (image: HTMLImageElement) => void
-  checkStyleMutation: (image: HTMLImageElement) => void
+  revealImage: (image: ImageElement) => void
+  checkStyleMutation: (image: ImageElement) => void
   applyEffectToBlocked: () => void
   revealAll: () => void
+  start: () => void
+  stop: () => void
 }
 
+const IMAGE_SELECTOR = 'img,svg image'
+
 export class ImageFilter extends Filter implements IImageFilter {
-  private readonly MIN_IMAGE_SIZE: number
-  // Bumped when filtering is turned off. A verdict from before that is for a page
-  // the user has since asked us to leave alone.
-  private epoch: number
-  private unhidden: WeakSet<HTMLImageElement>
+  private epoch = 0
+  private active = true
+  private unhidden = new WeakSet<ImageElement>()
+  private readonly sources = new WeakMap<ImageElement, string>()
+  private readonly wired = new WeakSet<ImageElement>()
+  private readonly smallImages = new WeakSet<ImageElement>()
 
-  constructor () {
-    super()
-    this.MIN_IMAGE_SIZE = 41
-    this.epoch = 0
-    this.unhidden = new WeakSet()
-  }
-
-  // User-initiated unhide from the right-click menu. Clears whatever effect was
-  // applied and tags the image `sfw` so analyzeImage won't re-filter it (and a
-  // later src change re-triggers analysis as usual).
-  public revealImage (image: HTMLImageElement): void {
+  public revealImage (image: ImageElement): void {
     this.unhidden.add(image)
     this.revealElement(image)
     image.dataset.nsfwFilterStatus = 'sfw'
   }
 
-  public analyzeImage (image: HTMLImageElement, srcAttribute: boolean = false): void {
-    // Only (re)process unseen images or images whose `src` just changed.
-    if (!srcAttribute && image.dataset.nsfwFilterStatus !== undefined) return
-    // A different image in the same element: the unhide the user gave the old one
-    // does not carry over.
-    if (srcAttribute) this.unhidden.delete(image)
-    if (image.src.length === 0) {
-      // An image whose src is cleared while a prediction is in flight would keep
-      // its `processing` tag and inline visibility:hidden forever: the pending
-      // result is for the old src, so showImage's url guard skips it. Reveal it —
-      // an empty image has nothing to filter, and a later real src re-triggers
-      // analysis via srcAttribute.
-      if (image.dataset.nsfwFilterStatus === 'processing') this.revealImage(image)
+  public analyzeImage (image: ImageElement): void {
+    if (!this.active) return
+    if (!this.wired.has(image)) {
+      this.wired.add(image)
+      // Responsive selection can change without a src mutation (picture, sizes,
+      // viewport or pixel density). load tells us which resource Chrome chose.
+      image.addEventListener('load', () => this.analyzeImage(image))
+    }
+
+    const source = this.sourceOf(image)
+    const previous = this.sources.get(image)
+    const status = image.dataset.nsfwFilterStatus
+    if (source === previous && status !== undefined && !this.smallImages.has(image)) return
+    if (source !== previous) this.unhidden.delete(image)
+    this.sources.set(image, source)
+
+    if (source === '') {
+      this.revealElement(image)
+      delete image.dataset.nsfwFilterStatus
       return
     }
 
-    // Images laid out smaller than MIN_IMAGE_SIZE in either dimension aren't
-    // filtered (icons, spacers, and the like), but they still need a status tag
-    // so the pending-hide stylesheet reveals them. A zero width or height means
-    // "not laid out yet", which is still a candidate.
-    const tooSmall =
-      image.width !== 0 && image.height !== 0 &&
-      (image.width <= this.MIN_IMAGE_SIZE || image.height <= this.MIN_IMAGE_SIZE)
-    if (tooSmall) {
-      // Reveal when untagged or when the src changed to a small icon mid-flight:
-      // the in-flight result is for the old src, so showImage's url guard would
-      // skip it and leave the image stuck hidden. A blocked image stays blocked.
-      const status = image.dataset.nsfwFilterStatus
-      if (status === undefined || status === 'processing') this.revealImage(image)
+    const { width, height } = image instanceof HTMLImageElement
+      ? image
+      : image.getBoundingClientRect()
+    if (this.belowMinSize(width, height)) {
+      this.smallImages.add(image)
+      // Small images are re-measured on every call, so only write when the tag
+      // is not already the one this would set.
+      if (status !== 'nsfw' && status !== 'sfw') this.showImage(image)
       return
     }
 
+    this.smallImages.delete(image)
     image.dataset.nsfwFilterStatus = 'processing'
-    this._analyzeImage(image)
+    this.hideElement(image)
+    void this._analyzeImage(image)
   }
 
-  // Some sites (Instagram, Google) rewrite an image's inline style on every
-  // re-render, wiping the effect we applied so a blocked image reappears. When
-  // the page clears the effect on a still-blocked image, put it back. The
-  // effect-intact check keeps this from looping against our own style writes.
-  public checkStyleMutation (image: HTMLImageElement): void {
-    const status = image.dataset.nsfwFilterStatus
-    // An in-flight image is hidden only by our inline visibility; a restyle wipes
-    // it. Keep it hidden (not revealed-with-effect: it isn't classified yet) until
-    // the prediction returns and either reveals or blocks it.
-    if (status === 'processing') {
-      if (image.style.visibility !== 'hidden') this.hideElement(image)
-      return
+  public checkStyleMutation (image: ImageElement): void {
+    if (this.smallImages.has(image)) this.analyzeImage(image)
+    super.checkStyleMutation(image)
+  }
+
+  public applyEffectToBlocked (): void {
+    for (const image of mediaElements<ImageElement>(IMAGE_SELECTOR)) {
+      if (this.isBlocked(image)) this.applyEffect(image)
     }
-    if (status !== 'nsfw') return
-    if (this.isEffectApplied(image)) return
+  }
+
+  public revealAll (): void {
+    this.epoch++
+    this.unhidden = new WeakSet()
+    for (const image of mediaElements<ImageElement>(IMAGE_SELECTOR)) {
+      if (image.dataset.nsfwFilterStatus === undefined) continue
+      this.revealElement(image)
+      this.sources.delete(image)
+      delete image.dataset.nsfwFilterStatus
+    }
+  }
+
+  public start (): void {
+    this.active = true
+  }
+
+  public stop (): void {
+    this.active = false
+    this.epoch++
+  }
+
+  private sourceOf (image: ImageElement): string {
+    if (image instanceof HTMLImageElement) return image.currentSrc || image.src
+    const href = image.href.baseVal
+    try {
+      return href === '' ? '' : new URL(href, image.baseURI).href
+    } catch {
+      // Let image loading report an invalid source without interrupting the scan.
+      return href
+    }
+  }
+
+  private async _analyzeImage (image: ImageElement): Promise<void> {
+    const source = this.sourceOf(image)
+    const epoch = this.epoch
+    const current = (): boolean =>
+      this.epoch === epoch && this.sourceOf(image) === source && !this.unhidden.has(image)
+
+    try {
+      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(source))
+      if (!current()) return
+      if (error !== undefined) {
+        this.markUnavailable(image)
+      } else if (result) {
+        this.blockedItems++
+        image.dataset.nsfwFilterStatus = 'nsfw'
+        this.applyEffect(image)
+      } else {
+        this.showImage(image)
+      }
+    } catch {
+      if (current()) this.markUnavailable(image)
+    }
+  }
+
+  private markUnavailable (image: ImageElement): void {
+    image.dataset.nsfwFilterStatus = 'unavailable'
     this.applyEffect(image)
   }
 
-  // A live filterEffect change (blur -> grayscale -> hide) doesn't alter the
-  // NSFW verdict, only how it's shown, so re-render every already-blocked image
-  // from the current setting instead of reclassifying. applyEffect clears the
-  // other modes' styles, so switching modes doesn't leave a stale blur behind.
-  public applyEffectToBlocked (): void {
-    const blocked = document.querySelectorAll<HTMLImageElement>('img[data-nsfw-filter-status="nsfw"]')
-    blocked.forEach(image => this.applyEffect(image))
-  }
-
-  // Live pause / allow-list of the current page: bring back every image we
-  // touched. Clearing the status (not tagging sfw) means a later re-enable's
-  // sweep reclassifies them rather than trusting a verdict made while off.
-  public revealAll (): void {
-    this.epoch++
-    // Dropping the user's unhides too: kept, they would discard the verdict for
-    // an image re-enabled filtering has already hidden.
-    this.unhidden = new WeakSet()
-
-    const filtered = document.querySelectorAll<HTMLImageElement>('img[data-nsfw-filter-status]')
-    filtered.forEach(image => {
-      this.revealElement(image)
-      delete image.dataset.nsfwFilterStatus
-    })
-  }
-
-  private _analyzeImage (image: HTMLImageElement): void {
-    this.hideElement(image)
-
-    // A verdict applies to the src it was asked about, on a page still being
-    // filtered. Filtering can be switched off and the src can change while the
-    // request is out, and hiding on a late verdict is not recoverable from.
-    const epoch = this.epoch
-    const request = new PredictionRequest(image.src)
-    this.requestToAnalyzeImage(request)
-      .then(({ result, url }) => {
-        if (this.epoch !== epoch || image.src !== url || this.unhidden.has(image)) return
-
-        if (result) {
-          this.blockedItems++
-          image.dataset.nsfwFilterStatus = 'nsfw'
-          this.applyEffect(image)
-        } else {
-          this.showImage(image)
-        }
-      }).catch(({ url }) => {
-        if (this.epoch !== epoch || image.src !== url) return
-
-        this.showImage(image)
-      })
-  }
-
-  private showImage (image: HTMLImageElement): void {
+  private showImage (image: ImageElement): void {
     image.dataset.nsfwFilterStatus = 'sfw'
     this.revealElement(image)
   }

--- a/src/content/Filter/VideoFilter.ts
+++ b/src/content/Filter/VideoFilter.ts
@@ -1,7 +1,7 @@
 import { PredictionRequest } from '../../utils/messages'
 import { mediaElements } from '../mediaRoots'
 
-import { Filter } from './Filter'
+import { Filter, OFFSCREEN_MARGIN } from './Filter'
 
 export type IVideoFilter = {
   analyzeVideo: (video: HTMLVideoElement, sourceChanged: boolean) => void
@@ -39,7 +39,6 @@ const FRAME_PRESENTATION_TIMEOUT = 250
 // Sampling follows media time, not wall time: a paused or buffering video is not
 // showing anything new, and a 2x playback is showing it twice as fast.
 const SAMPLE_INTERVAL = 1
-const OFFSCREEN_MARGIN = '300px'
 
 // Frames are keyed, not addressed, and the background deduplicates by key across
 // every tab. A counter alone would hand tab B the verdict for tab A's frame, so
@@ -303,7 +302,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
   private schedule (video: HTMLVideoElement): void {
     const state = this.stateOf(video)
     if (!this.active || state.overridden || state.unsampleable) return
-    if (video.dataset.nsfwFilterStatus === 'nsfw') return
+    if (this.isBlocked(video)) return
 
     // Hide decoded footage before checking viewport eligibility: intersection
     // callbacks may arrive after its first paint, including behind a safe poster.
@@ -320,7 +319,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
 
   private eligible (video: HTMLVideoElement, state: VideoState): boolean {
     if (!this.active || state.unsampleable || state.overridden) return false
-    if (video.dataset.nsfwFilterStatus === 'nsfw') return false
+    if (this.isBlocked(video)) return false
     const pictureInPicture = document.pictureInPictureElement === video
     if (!pictureInPicture && (!this.visible.has(video) || document.visibilityState !== 'visible')) return false
     // Empty placeholders must not delay videos that already have pixels to read.
@@ -378,7 +377,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
   private async sample (video: HTMLVideoElement): Promise<void> {
     const state = this.stateOf(video)
     const generation = state.generation
-    if (state.unsampleable || video.dataset.nsfwFilterStatus === 'nsfw') return
+    if (state.unsampleable || this.isBlocked(video)) return
 
     // Until a frame of this media has been cleared, the element is hidden. Later
     // samples run behind a video the user is already watching: blocking on every

--- a/src/content/Filter/VideoFilter.ts
+++ b/src/content/Filter/VideoFilter.ts
@@ -135,7 +135,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
       }
       return
     }
-    if (video.dataset.nsfwFilterStatus === 'nsfw') return
+    if (this.isBlocked(video)) return
     // Until the video has played, the poster is what is on screen, however many
     // frames have been decoded and judged behind it.
     if (state.approved === state.generation && video.played.length > 0) return
@@ -249,7 +249,10 @@ export class VideoFilter extends Filter implements IVideoFilter {
     // Seeking exposes a frame nothing has judged, including while paused.
     video.addEventListener('seeking', () => {
       if (!this.active || state.overridden || state.unsampleable) return
-      if (video.dataset.nsfwFilterStatus === 'nsfw') return
+      // Blocked stays blocked until the element plays different media, which
+      // resets it. Seeking inside the same footage would otherwise clear the
+      // status and hand it back for another look that already failed once.
+      if (this.isBlocked(video)) return
       // A loop returns to footage from the same source. Cancelling every pending
       // verdict on each lap would keep a short safe loop hidden indefinitely.
       if (video.loop && video.currentTime === 0) {

--- a/src/content/Filter/VideoFilter.ts
+++ b/src/content/Filter/VideoFilter.ts
@@ -1,4 +1,5 @@
 import { PredictionRequest } from '../../utils/messages'
+import { mediaElements } from '../mediaRoots'
 
 import { Filter } from './Filter'
 
@@ -34,14 +35,10 @@ type VideoState = {
 
 const FRAME_SIZE = 224
 const FRAME_QUALITY = 0.8
-const MIN_VIDEO_SIZE = 41
+const FRAME_PRESENTATION_TIMEOUT = 250
 // Sampling follows media time, not wall time: a paused or buffering video is not
 // showing anything new, and a 2x playback is showing it twice as fast.
-const SAMPLE_INTERVAL = 10
-// A video can be laid out long before it has a frame to give (preload="none",
-// a slow network). Reveal it rather than hold a hidden element on a frame that
-// may never decode.
-const FRAME_DEADLINE = 3000
+const SAMPLE_INTERVAL = 1
 const OFFSCREEN_MARGIN = '300px'
 
 // Frames are keyed, not addressed, and the background deduplicates by key across
@@ -82,7 +79,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
     if (!this.active) {
       // Filtering was turned off while this video was out of the document, so
       // revealAll() never reached it. It comes back filtered otherwise.
-      if (video.dataset.nsfwFilterStatus !== undefined) this.retire(video)
+      if (video.dataset.nsfwFilterStatus !== undefined) this.reset(video, this.stateOf(video))
       return
     }
 
@@ -104,16 +101,11 @@ export class VideoFilter extends Filter implements IVideoFilter {
         return
       }
 
-      if (video.poster.length > 0) {
-        video.dataset.nsfwFilterStatus = 'processing'
-        this.hideElement(video)
-        this.classifyPoster(video, state)
-      } else {
-        // Nothing on screen to judge yet. The frame that appears is judged below,
-        // and until then the element has to carry a status or the pending-hide
-        // stylesheet keeps hiding it.
-        video.dataset.nsfwFilterStatus = 'sfw'
-      }
+      // Decoding can finish before the viewport observer reports this video, so
+      // the first frame stays hidden until something has actually inspected it.
+      video.dataset.nsfwFilterStatus = 'processing'
+      this.hideElement(video)
+      if (video.poster.length > 0) void this.classifyPoster(video, state)
     }
 
     // A paused video still shows its first decoded frame, so having one is reason
@@ -145,7 +137,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
     state.posterGeneration++
     video.dataset.nsfwFilterStatus = 'processing'
     this.hideElement(video)
-    this.classifyPoster(video, state)
+    void this.classifyPoster(video, state)
   }
 
   // User-initiated unhide from the right-click menu. Sampling stops until the
@@ -154,7 +146,6 @@ export class VideoFilter extends Filter implements IVideoFilter {
   public revealVideo (video: HTMLVideoElement): void {
     const state = this.stateOf(video)
     state.approved = state.generation
-    state.unsampleable = true
     state.overridden = true
     this.due.delete(video)
 
@@ -162,41 +153,20 @@ export class VideoFilter extends Filter implements IVideoFilter {
     video.dataset.nsfwFilterStatus = 'sfw'
   }
 
-  public checkStyleMutation (video: HTMLVideoElement): void {
-    const status = video.dataset.nsfwFilterStatus
-    if (status === 'processing') {
-      if (video.style.visibility !== 'hidden') this.hideElement(video)
-      return
-    }
-    if (status !== 'nsfw') return
-    if (this.isEffectApplied(video)) return
-    this.applyEffect(video)
-  }
-
   public applyEffectToBlocked (): void {
-    const blocked = document.querySelectorAll<HTMLVideoElement>('video[data-nsfw-filter-status="nsfw"]')
+    const blocked = mediaElements<HTMLVideoElement>(
+      'video[data-nsfw-filter-status="nsfw"],video[data-nsfw-filter-status="unavailable"]'
+    )
     blocked.forEach(video => this.applyEffect(video))
-  }
-
-  public revealAll (): void {
-    const filtered = document.querySelectorAll<HTMLVideoElement>('video[data-nsfw-filter-status]')
-    filtered.forEach(video => this.retire(video))
   }
 
   // A verdict reached while filtering was on does not survive being turned off
   // and on again, the same way images are reclassified rather than trusted. The
   // user's unhide goes with it, or the next verdict is dropped and the video
   // stays hidden.
-  private retire (video: HTMLVideoElement): void {
-    this.revealElement(video)
-    delete video.dataset.nsfwFilterStatus
-    this.due.delete(video)
-
-    const state = this.stateOf(video)
-    state.generation++
-    state.unsampleable = false
-    state.framePending = false
-    state.overridden = false
+  public revealAll (): void {
+    const filtered = mediaElements<HTMLVideoElement>('video[data-nsfw-filter-status]')
+    filtered.forEach(video => this.reset(video, this.stateOf(video)))
   }
 
   // Filtering was turned off for this page. The elements stay wired, so turning
@@ -262,7 +232,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
     video.addEventListener('play', () => {
       // A page that calls play() on a blocked video gets it back paused rather
       // than playing behind the effect.
-      if (video.dataset.nsfwFilterStatus === 'nsfw') {
+      if (this.isBlocked(video)) {
         video.pause()
         return
       }
@@ -271,8 +241,32 @@ export class VideoFilter extends Filter implements IVideoFilter {
     // The first decoded frame is on screen whether or not anything is playing.
     video.addEventListener('loadeddata', () => this.schedule(video))
     // Seeking exposes a frame nothing has judged, including while paused.
+    video.addEventListener('seeking', () => {
+      if (!this.active || state.overridden || state.unsampleable) return
+      if (video.dataset.nsfwFilterStatus === 'nsfw') return
+      // A loop returns to footage from the same source. Cancelling every pending
+      // verdict on each lap would keep a short safe loop hidden indefinitely.
+      if (video.loop && video.currentTime === 0) {
+        state.lastSampleTime = Number.NEGATIVE_INFINITY
+        return
+      }
+      state.generation++
+      state.approved = -1
+      state.lastSampleTime = Number.NEGATIVE_INFINITY
+      state.framePending = true
+      video.dataset.nsfwFilterStatus = 'processing'
+      this.hideElement(video)
+    })
     video.addEventListener('seeked', () => this.schedule(video))
     video.addEventListener('timeupdate', () => this.schedule(video))
+    video.addEventListener('enterpictureinpicture', () => {
+      if (this.isBlocked(video)) {
+        video.pause()
+        this.exitPictureInPicture(video)
+      } else {
+        this.schedule(video)
+      }
+    })
   }
 
   private onIntersection (entries: IntersectionObserverEntry[]): void {
@@ -296,16 +290,23 @@ export class VideoFilter extends Filter implements IVideoFilter {
   }
 
   private tooSmall (video: HTMLVideoElement): boolean {
-    const width = video.clientWidth
-    const height = video.clientHeight
-
-    return width !== 0 && height !== 0 && (width <= MIN_VIDEO_SIZE || height <= MIN_VIDEO_SIZE)
+    return this.belowMinSize(video.clientWidth, video.clientHeight)
   }
 
   private schedule (video: HTMLVideoElement): void {
     const state = this.stateOf(video)
-    if (!this.eligible(video, state)) return
+    if (!this.active || state.overridden || state.unsampleable) return
+    if (video.dataset.nsfwFilterStatus === 'nsfw') return
 
+    // Hide decoded footage before checking viewport eligibility: intersection
+    // callbacks may arrive after its first paint, including behind a safe poster.
+    if (state.approved !== state.generation &&
+        video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && !this.tooSmall(video)) {
+      state.framePending = true
+      video.dataset.nsfwFilterStatus = 'processing'
+      this.hideElement(video)
+    }
+    if (!this.eligible(video, state)) return
     this.due.add(video)
     void this.drain()
   }
@@ -313,7 +314,10 @@ export class VideoFilter extends Filter implements IVideoFilter {
   private eligible (video: HTMLVideoElement, state: VideoState): boolean {
     if (!this.active || state.unsampleable || state.overridden) return false
     if (video.dataset.nsfwFilterStatus === 'nsfw') return false
-    if (!this.visible.has(video) || document.visibilityState !== 'visible') return false
+    const pictureInPicture = document.pictureInPictureElement === video
+    if (!pictureInPicture && (!this.visible.has(video) || document.visibilityState !== 'visible')) return false
+    // Empty placeholders must not delay videos that already have pixels to read.
+    if (video.seeking || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return false
     if (this.tooSmall(video)) return false
     // Once a frame of this media has been cleared, resample only as the footage
     // moves on. Everything that can happen to a video on a busy page routes
@@ -371,7 +375,7 @@ export class VideoFilter extends Filter implements IVideoFilter {
 
     // Until a frame of this media has been cleared, the element is hidden. Later
     // samples run behind a video the user is already watching: blocking on every
-    // one of them would blink the page every ten seconds.
+    // one of them would blink the page on every sample.
     const first = state.approved !== generation
     if (first) {
       video.dataset.nsfwFilterStatus = 'processing'
@@ -381,7 +385,8 @@ export class VideoFilter extends Filter implements IVideoFilter {
     const frame = await this.captureFrame(video, state)
     if (!this.stillCurrent(state, generation)) return
     if (frame === null) {
-      if (first) this.markUnavailable(video)
+      state.framePending = false
+      this.markUnavailable(video)
       return
     }
     // From here there is decoded footage on screen behind the hide, so nothing
@@ -391,19 +396,22 @@ export class VideoFilter extends Filter implements IVideoFilter {
     state.lastSampleTime = video.currentTime
 
     try {
-      const { result } = await this.requestToAnalyzeImage(new PredictionRequest(frameKey(), frame))
-      if (first) state.framePending = false
+      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(frameKey(), frame))
       if (!this.stillCurrent(state, generation)) return
+      if (first) state.framePending = false
 
-      if (result) {
+      if (error !== undefined) {
+        this.markUnavailable(video)
+      } else if (result) {
         this.block(video)
       } else {
         state.approved = generation
         if (first) this.reveal(video)
       }
     } catch {
+      if (!this.stillCurrent(state, generation)) return
       if (first) state.framePending = false
-      if (this.stillCurrent(state, generation) && first) this.markUnavailable(video)
+      this.markUnavailable(video)
     }
   }
 
@@ -413,13 +421,29 @@ export class VideoFilter extends Filter implements IVideoFilter {
     return this.active && !state.overridden && state.generation === generation
   }
 
-  // null means no frame to classify: either none has decoded within the deadline,
-  // or the canvas is tainted by media this document may not read back.
+  // Only decoded videos enter the queue. null means this document cannot read
+  // their pixels, even though Chrome can play them.
   private async captureFrame (video: HTMLVideoElement, state: VideoState): Promise<string | null> {
-    if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-      const decoded = await this.waitForFrame(video)
-      if (!decoded) return null
+    const generation = state.generation
+    // loadeddata can precede presentation: canvas would then contain black
+    // pixels, not the decoded frame. A paused frame may already be presented and
+    // produce no further callback, so bound this wait.
+    if (state.approved !== state.generation && typeof video.requestVideoFrameCallback === 'function') {
+      await new Promise<void>(resolve => {
+        // Each side cancels the other, so the handle is in place before either
+        // can run rather than being read out of its own declaration.
+        let frameCallback = 0
+        const timer = setTimeout(() => {
+          video.cancelVideoFrameCallback(frameCallback)
+          resolve()
+        }, FRAME_PRESENTATION_TIMEOUT)
+        frameCallback = video.requestVideoFrameCallback(() => {
+          clearTimeout(timer)
+          resolve()
+        })
+      })
     }
+    if (state.generation !== generation) return null
 
     // A fresh canvas per capture: one tainted by a cross-origin video must not
     // fail every capture after it.
@@ -436,47 +460,46 @@ export class VideoFilter extends Filter implements IVideoFilter {
       return canvas.toDataURL('image/jpeg', FRAME_QUALITY)
     } catch {
       // SecurityError: cross-origin media without CORS, or DRM. The page can play
-      // it, we cannot read it, and retrying costs the same every ten seconds.
+      // it, we cannot read it, and retrying cannot change that.
       state.unsampleable = true
 
       return null
     }
   }
 
-  private async waitForFrame (video: HTMLVideoElement): Promise<boolean> {
-    return await new Promise(resolve => {
-      const settle = (decoded: boolean): void => {
-        window.clearTimeout(timer)
-        video.removeEventListener('loadeddata', onLoaded)
-        resolve(decoded)
-      }
-      const onLoaded = (): void => settle(true)
-
-      const timer = window.setTimeout(() => settle(false), FRAME_DEADLINE)
-      video.addEventListener('loadeddata', onLoaded)
-    })
-  }
-
-  private classifyPoster (video: HTMLVideoElement, state: VideoState): void {
+  // A safe poster only clears the preview, never the footage behind it: it does
+  // not count as an approved frame, and it cannot speak for a frame still being
+  // judged. A blocked poster blocks regardless, since it is what is on screen.
+  private async classifyPoster (video: HTMLVideoElement, state: VideoState): Promise<void> {
     const generation = state.generation
     const posterGeneration = state.posterGeneration
     const poster = video.poster
     const current = (): boolean =>
-      this.stillCurrent(state, generation) && state.posterGeneration === posterGeneration && video.poster === poster
+      this.stillCurrent(state, generation) &&
+      state.posterGeneration === posterGeneration && video.poster === poster
 
-    this.requestToAnalyzeImage(new PredictionRequest(poster))
-      .then(({ result }) => {
-        if (!current()) return
+    let blocked = false
+    let unavailable = false
+    try {
+      const { result, error } = await this.requestToAnalyzeImage(new PredictionRequest(poster))
+      blocked = result
+      unavailable = error !== undefined
+    } catch {
+      unavailable = true
+    }
 
-        // A safe poster only clears the preview, never the footage behind it, so
-        // it does not count as an approved frame, and it cannot reveal footage a
-        // frame is still being judged for.
-        if (result) this.block(video)
-        else if (!state.framePending) this.reveal(video)
-      })
-      .catch(() => {
-        if (current() && !state.framePending) this.reveal(video)
-      })
+    if (!current()) return
+    if (blocked) {
+      this.block(video)
+      return
+    }
+    if (state.framePending) return
+    if (!unavailable) {
+      this.reveal(video)
+      return
+    }
+    // An unreadable poster must not blank footage a frame has already cleared.
+    if (state.approved !== state.generation) this.markUnavailable(video)
   }
 
   private block (video: HTMLVideoElement): void {
@@ -485,12 +508,13 @@ export class VideoFilter extends Filter implements IVideoFilter {
     this.due.delete(video)
     this.applyEffect(video)
     video.pause()
+    this.exitPictureInPicture(video)
   }
 
   // A frame and a poster can be in flight together, and either can come back
   // first. Whichever loses the race must not put an unsafe video back on screen.
   private reveal (video: HTMLVideoElement): void {
-    if (video.dataset.nsfwFilterStatus === 'nsfw') return
+    if (this.isBlocked(video)) return
 
     video.dataset.nsfwFilterStatus = 'sfw'
     this.revealElement(video)
@@ -500,6 +524,13 @@ export class VideoFilter extends Filter implements IVideoFilter {
     if (video.dataset.nsfwFilterStatus === 'nsfw') return
 
     video.dataset.nsfwFilterStatus = 'unavailable'
-    this.revealElement(video)
+    this.applyEffect(video)
+    video.pause()
+    this.exitPictureInPicture(video)
+  }
+
+  private exitPictureInPicture (video: HTMLVideoElement): void {
+    if (document.pictureInPictureElement !== video) return
+    void document.exitPictureInPicture().catch(() => undefined)
   }
 }

--- a/src/content/Filter/VideoFilter.ts
+++ b/src/content/Filter/VideoFilter.ts
@@ -102,10 +102,17 @@ export class VideoFilter extends Filter implements IVideoFilter {
       }
 
       // Decoding can finish before the viewport observer reports this video, so
-      // the first frame stays hidden until something has actually inspected it.
-      video.dataset.nsfwFilterStatus = 'processing'
-      this.hideElement(video)
-      if (video.poster.length > 0) void this.classifyPoster(video, state)
+      // anything already on screen stays hidden until it has been inspected.
+      if (video.poster.length > 0 || video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        video.dataset.nsfwFilterStatus = 'processing'
+        this.hideElement(video)
+        if (video.poster.length > 0) void this.classifyPoster(video, state)
+      } else {
+        // Nothing decoded and no poster: nothing is on screen to judge yet, and
+        // the element needs a status or the pending rule keeps hiding it. The
+        // first decoded frame is hidden by schedule().
+        video.dataset.nsfwFilterStatus = 'sfw'
+      }
     }
 
     // A paused video still shows its first decoded frame, so having one is reason
@@ -498,8 +505,10 @@ export class VideoFilter extends Filter implements IVideoFilter {
       this.reveal(video)
       return
     }
-    // An unreadable poster must not blank footage a frame has already cleared.
-    if (state.approved !== state.generation) this.markUnavailable(video)
+    // An unreadable poster says nothing about the footage behind it, so let a
+    // frame decide. Only media whose pixels cannot be read at all is unavailable.
+    if (state.unsampleable) this.markUnavailable(video)
+    else this.schedule(video)
   }
 
   private block (video: HTMLVideoElement): void {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -4,12 +4,15 @@ import { createChromeStore } from '../popup/redux/chrome-storage'
 import { rootReducer } from '../popup/redux/reducers'
 import { SettingsState } from '../popup/redux/reducers/settings'
 import { isHostAllowed } from '../utils/allowlist'
-import { CONTEXT_TARGET, UNHIDE_IMAGE, UnhideImageMessage } from '../utils/messages'
+import { CONTEXT_TARGET, PAGE_HOST, UNHIDE_IMAGE, UnhideImageMessage } from '../utils/messages'
 
 import { DOMWatcher } from './DOMWatcher/DOMWatcher'
+import { HIDE_STYLE_ID, injectPendingHide } from './DOMWatcher/pendingStyle'
 import { BackgroundImageFilter } from './Filter/BackgroundImageFilter'
-import { ImageFilter } from './Filter/ImageFilter'
+import { CanvasFilter } from './Filter/CanvasFilter'
+import { ImageElement, ImageFilter } from './Filter/ImageFilter'
 import { VideoFilter } from './Filter/VideoFilter'
+import { mediaElements } from './mediaRoots'
 
 // chrome.storage reads are async, so there is a gap between document_start (when
 // this script runs) and the store resolving and the observer attaching. Images
@@ -17,35 +20,33 @@ import { VideoFilter } from './Filter/VideoFilter'
 // that, inject a stylesheet at document_start that hides every image the filter
 // hasn't tagged yet. Once ImageFilter sets data-nsfw-filter-status, the per-image
 // inline styles take over, so blur and grayscale modes are unaffected.
-const HIDE_STYLE_ID = 'nsfw-filter-pending-hide'
 // Backstop: if the store somehow never settles, reveal images rather than
 // leaving the page permanently blank (matches the "show images if we can't
 // filter" degradation of the .catch branch below).
 const HIDE_STYLE_SAFETY_TIMEOUT = 4000
 
-const injectPendingHide = (): void => {
-  const style = document.createElement('style')
-  style.id = HIDE_STYLE_ID
-  style.textContent =
-    'img:not([data-nsfw-filter-status]),video:not([data-nsfw-filter-status]){visibility:hidden !important}'
-  document.documentElement.appendChild(style)
-}
-
 const removePendingHide = (): void => {
-  document.getElementById(HIDE_STYLE_ID)?.remove()
+  mediaElements(`#${HIDE_STYLE_ID}`).forEach(style => style.remove())
 }
 
 // Wire the right-click "unhide" menu. On every context-menu open we tell the
 // service worker whether the cursor is over an image we filtered, so it can show
 // the menu item only then; if the user picks it, the worker messages this frame
 // to reveal the element we last reported.
-const wireContextMenuUnhide = (imageFilter: ImageFilter, videoFilter: VideoFilter): void => {
-  let lastTarget: HTMLImageElement | HTMLVideoElement | null = null
+const wireContextMenuUnhide = (
+  imageFilter: ImageFilter,
+  videoFilter: VideoFilter,
+  canvasFilter: CanvasFilter
+): void => {
+  let lastTarget: ImageElement | HTMLVideoElement | HTMLCanvasElement | null = null
 
   document.addEventListener('contextmenu', event => {
-    const target = event.target
-    const media = target instanceof HTMLImageElement || target instanceof HTMLVideoElement
-    const filtered = media && target.dataset.nsfwFilterStatus === 'nsfw'
+    const found = event.composedPath().find(node =>
+      node instanceof Element && node.matches('img,video,canvas,svg image')
+    )
+    const target = (found ?? null) as ImageElement | HTMLVideoElement | HTMLCanvasElement | null
+    const status = target?.dataset.nsfwFilterStatus
+    const filtered = status === 'nsfw' || status === 'unavailable'
     lastTarget = filtered ? target : null
     chrome.runtime.sendMessage({ type: CONTEXT_TARGET, filtered }).catch(() => undefined)
   }, true)
@@ -54,8 +55,13 @@ const wireContextMenuUnhide = (imageFilter: ImageFilter, videoFilter: VideoFilte
     if (message?.type !== UNHIDE_IMAGE) return
     if (lastTarget === null) return
 
-    if (lastTarget instanceof HTMLVideoElement) videoFilter.revealVideo(lastTarget)
-    else imageFilter.revealImage(lastTarget)
+    if (lastTarget instanceof HTMLVideoElement) {
+      videoFilter.revealVideo(lastTarget)
+    } else if (lastTarget instanceof HTMLCanvasElement) {
+      canvasFilter.revealCanvas(lastTarget)
+    } else {
+      imageFilter.revealImage(lastTarget)
+    }
     lastTarget = null
   })
 }
@@ -63,34 +69,44 @@ const wireContextMenuUnhide = (imageFilter: ImageFilter, videoFilter: VideoFilte
 const init = (): void => {
   const imageFilter = new ImageFilter()
   const videoFilter = new VideoFilter()
-
-  // The unhide menu must work per-frame: contextmenu events don't cross the
-  // iframe boundary, and the background targets the UNHIDE reply to the exact
-  // frame that reported the image. So wire reporting/unhide in every frame, but
-  // keep the actual filtering (DOMWatcher, pending-hide, store) top-frame only.
-  // Without this, the menu's global visibility goes stale over iframe images.
-  wireContextMenuUnhide(imageFilter, videoFilter)
-
-  // Ignore iframes for filtering, https://stackoverflow.com/a/326076/10432429
-  if (window.self !== window.top) return
-
+  const canvasFilter = new CanvasFilter()
   const backgroundFilter = new BackgroundImageFilter()
-  const domWatcher = new DOMWatcher(imageFilter, videoFilter, backgroundFilter)
+  const domWatcher = new DOMWatcher(imageFilter, videoFilter, backgroundFilter, canvasFilter)
 
-  injectPendingHide()
+  wireContextMenuUnhide(imageFilter, videoFilter, canvasFilter)
+
+  // The three element filters share a lifecycle. Naming the set once keeps a new
+  // filter from being added to some of these steps and missed in the others.
+  const mediaFilters = [imageFilter, videoFilter, canvasFilter]
+  const setEffect = (filterEffect: SettingsState['filterEffect']): void => {
+    for (const filter of mediaFilters) filter.setSettings({ filterEffect })
+  }
+
+  injectPendingHide(document)
   const safety = setTimeout(removePendingHide, HIDE_STYLE_SAFETY_TIMEOUT)
 
   // Whether this page should be filtered right now, from a settings snapshot.
+  let pageHost = window.location.hostname
   const shouldFilter = (settings: SettingsState): boolean =>
-    settings.enabled && !isHostAllowed(window.location.hostname, settings.websites)
+    settings.enabled && !isHostAllowed(pageHost, settings.websites)
 
-  createChromeStore({ createStore })(rootReducer)
-    .then(store => {
+  // sendMessage throws synchronously once the extension context is gone, which a
+  // .catch() on the returned promise never sees.
+  const askPageHost = async (): Promise<unknown> => {
+    try {
+      return await chrome.runtime.sendMessage({ type: PAGE_HOST })
+    } catch {
+      return pageHost
+    }
+  }
+
+  Promise.all([createChromeStore({ createStore })(rootReducer), askPageHost()])
+    .then(([store, host]) => {
+      if (typeof host === 'string') pageHost = host
       clearTimeout(safety)
 
       let previous = store.getState().settings
-      imageFilter.setSettings({ filterEffect: previous.filterEffect })
-      videoFilter.setSettings({ filterEffect: previous.filterEffect })
+      setEffect(previous.filterEffect)
 
       let filtering = shouldFilter(previous)
       if (filtering) {
@@ -101,6 +117,7 @@ const init = (): void => {
       } else {
         // Extension turned off, or filtering disabled for this site: reveal everything.
         backgroundFilter.stop()
+        for (const filter of mediaFilters) filter.stop()
         removePendingHide()
       }
 
@@ -114,11 +131,10 @@ const init = (): void => {
         previous = next
 
         if (next.filterEffect !== prev.filterEffect) {
-          imageFilter.setSettings({ filterEffect: next.filterEffect })
-          videoFilter.setSettings({ filterEffect: next.filterEffect })
+          setEffect(next.filterEffect)
+          // A new effect is not a new verdict: re-render what is already blocked.
           if (filtering) {
-            imageFilter.applyEffectToBlocked()
-            videoFilter.applyEffectToBlocked()
+            for (const filter of mediaFilters) filter.applyEffectToBlocked()
           }
         }
 
@@ -127,24 +143,24 @@ const init = (): void => {
         filtering = nextFiltering
 
         if (filtering) {
-          videoFilter.start()
+          for (const filter of mediaFilters) filter.start()
           backgroundFilter.start()
           domWatcher.watch()
         } else {
           domWatcher.unwatch()
+          // Stop before revealing: stop() is what keeps a verdict still in flight
+          // from applying, so revealing first can be undone by a late reply.
+          for (const filter of mediaFilters) filter.stop()
           backgroundFilter.stop()
           removePendingHide()
-          imageFilter.revealAll()
-          videoFilter.revealAll()
-          videoFilter.stop()
+          for (const filter of mediaFilters) filter.revealAll()
           backgroundFilter.revealAll()
         }
       })
     })
     .catch(error => {
       console.warn(error)
-      imageFilter.setSettings({ filterEffect: 'blur' })
-      videoFilter.setSettings({ filterEffect: 'blur' })
+      setEffect('blur')
       backgroundFilter.stop()
       clearTimeout(safety)
       removePendingHide()

--- a/src/content/mediaChanges.ts
+++ b/src/content/mediaChanges.ts
@@ -1,0 +1,2 @@
+export const SHADOW_ROOT_CREATED = 'nsfw-filter-shadow-root-created'
+export const CANVAS_DRAWN = 'nsfw-filter-canvas-drawn'

--- a/src/content/mediaGuard.ts
+++ b/src/content/mediaGuard.ts
@@ -1,0 +1,65 @@
+import { PENDING_HIDE_RULES } from './DOMWatcher/pendingStyle'
+import { CANVAS_DRAWN, SHADOW_ROOT_CREATED } from './mediaChanges'
+
+// These APIs do not produce DOM mutations. Notify the isolated content script
+// before paint; all pixel inspection and filtering decisions stay there.
+const attachShadow = Element.prototype.attachShadow
+// Setting root.innerHTML must not remove the protection before startup finishes.
+const shadowStyle = new CSSStyleSheet()
+shadowStyle.replaceSync(PENDING_HIDE_RULES)
+Element.prototype.attachShadow = function (options) {
+  const root = attachShadow.call(this, options)
+  // A root in another document paints nothing here, and adopting a sheet this
+  // document constructed would throw inside the page's own attachShadow call.
+  if (this.ownerDocument === document) {
+    root.adoptedStyleSheets.push(shadowStyle)
+    // The host, not the root: a closed root reached through this event would be
+    // one the page cannot otherwise get to. The isolated side resolves it itself.
+    document.dispatchEvent(new CustomEvent(SHADOW_ROOT_CREATED, { detail: this }))
+  }
+  return root
+}
+
+const drawn = new Set<HTMLCanvasElement>()
+const notifyDrawing = (canvas: HTMLCanvasElement): void => {
+  if (!canvas.isConnected) return
+  const scheduled = drawn.size > 0
+  drawn.add(canvas)
+  if (scheduled) return
+  // A frame often clears and redraws the same canvas many times. Inspect its
+  // completed drawing once, after those calls and before the browser paints it.
+  queueMicrotask(() => {
+    const batch = [...drawn]
+    drawn.clear()
+    for (const canvas of batch) {
+      canvas.dispatchEvent(new Event(CANVAS_DRAWN, { bubbles: true, composed: true }))
+    }
+  })
+}
+
+const watchDrawing = (prototype: object, methods: string[]): void => {
+  for (const method of methods) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, method)
+    const draw = descriptor?.value
+    if (typeof draw !== 'function') continue
+    Object.defineProperty(prototype, method, {
+      ...descriptor,
+      value: function (this: { canvas: HTMLCanvasElement | OffscreenCanvas }, ...args: unknown[]) {
+        const result: unknown = Reflect.apply(draw, this, args)
+        if (this.canvas instanceof HTMLCanvasElement) notifyDrawing(this.canvas)
+        return result
+      }
+    })
+  }
+}
+
+watchDrawing(CanvasRenderingContext2D.prototype, [
+  'clearRect', 'fillRect', 'strokeRect', 'drawImage', 'putImageData',
+  'fill', 'stroke', 'fillText', 'strokeText', 'reset'
+])
+watchDrawing(ImageBitmapRenderingContext.prototype, ['transferFromImageBitmap'])
+watchDrawing(WebGLRenderingContext.prototype, ['clear', 'drawArrays', 'drawElements'])
+watchDrawing(WebGL2RenderingContext.prototype, [
+  'clear', 'drawArrays', 'drawElements', 'drawArraysInstanced', 'drawElementsInstanced',
+  'drawRangeElements', 'blitFramebuffer', 'clearBufferfv', 'clearBufferiv', 'clearBufferuiv', 'clearBufferfi'
+])

--- a/src/content/mediaRoots.ts
+++ b/src/content/mediaRoots.ts
@@ -1,0 +1,29 @@
+export type MediaRoot = Document | ShadowRoot
+
+export const shadowRootOf = (element: Element): ShadowRoot | null => {
+  if (element.shadowRoot !== null) return element.shadowRoot
+  if (!(element instanceof HTMLElement)) return null
+  if (typeof chrome === 'undefined') return null
+  return chrome.dom?.openOrClosedShadowRoot(element) ?? null
+}
+
+// Document selectors do not cross shadow boundaries. Use the same traversal for
+// discovering media and for restoring it when filtering is turned off.
+// Breadth-first, and the list grows as it is walked: shadow trees nest, so a
+// root found here is searched in its turn.
+export const mediaRoots = (root: ParentNode = document): ParentNode[] => {
+  const roots = [root]
+  for (let index = 0; index < roots.length; index++) {
+    const current = roots[index]
+    const elements = [...current.querySelectorAll('*')]
+    if (current instanceof Element) elements.unshift(current)
+    for (const element of elements) {
+      const shadow = shadowRootOf(element)
+      if (shadow !== null) roots.push(shadow)
+    }
+  }
+  return roots
+}
+
+export const mediaElements = <T extends Element>(selector: string): T[] =>
+  mediaRoots().flatMap(root => [...root.querySelectorAll<T>(selector)])

--- a/src/offscreen/classifyImage.ts
+++ b/src/offscreen/classifyImage.ts
@@ -11,7 +11,12 @@ const MAX_DECODED_FRAMES = 300
 // and every prediction is a second of a stalled queue on a machine without a GPU.
 const MAX_PREDICTIONS = 8
 const IMAGE_SIZE = 224
-const LOAD_TIMEOUT = 5000
+// Wall-clock, and it competes with inference for the same thread: a page full of
+// media has every retrieval waiting behind model work that blocks the task queue.
+// Five seconds cut those off and the caller read that as media it could not see,
+// which is blocked. The content-side deadline is the real backstop for a request
+// that never lands.
+const LOAD_TIMEOUT = 45000
 
 type Predict = (image: HTMLImageElement, label: string) => Promise<boolean>
 

--- a/src/offscreen/classifyImage.ts
+++ b/src/offscreen/classifyImage.ts
@@ -1,0 +1,100 @@
+import { withTimeout } from '../utils/withTimeout'
+
+// Decode animations in the extension document, where host permissions allow the
+// image download. File signatures matter: a GIF need not have a .gif URL or MIME.
+const MAX_DECODED_FRAMES = 300
+// An animation is a short video, and video is sampled on an interval rather than
+// frame by frame. Spread a fixed budget of predictions across the whole run: a
+// long animation can then be cleared, where inspecting every frame could only
+// ever run out of budget and leave safe content hidden. Eight of them across the
+// few seconds an animation usually runs is a tighter interval than video gets,
+// and every prediction is a second of a stalled queue on a machine without a GPU.
+const MAX_PREDICTIONS = 8
+const IMAGE_SIZE = 224
+const LOAD_TIMEOUT = 5000
+
+type Predict = (image: HTMLImageElement, label: string) => Promise<boolean>
+
+const loadImage = async (url: string): Promise<HTMLImageElement> => {
+  const image = new Image(IMAGE_SIZE, IMAGE_SIZE)
+  const loaded = new Promise<HTMLImageElement>((resolve, reject) => {
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Image could not be decoded'))
+    image.src = url
+  })
+  return await withTimeout(loaded, LOAD_TIMEOUT, 'Image load')
+}
+
+const animationType = async (blob: Blob): Promise<string | null> => {
+  const bytes = new Uint8Array(await blob.slice(0, 16).arrayBuffer())
+  const signature = String.fromCharCode(...bytes)
+  if (signature.startsWith('GIF87a') || signature.startsWith('GIF89a')) return 'image/gif'
+  if (signature.startsWith('\u0089PNG\r\n\u001a\n')) return 'image/png'
+  if (signature.startsWith('RIFF') && signature.slice(8, 12) === 'WEBP') return 'image/webp'
+  return null
+}
+
+// Evenly spaced across the animation, so the first and last frames are always
+// among them, ordered from the middle out: content following a safe intro is
+// found without decoding the run from the start.
+const sampleOrder = (frameCount: number): number[] => {
+  const count = Math.min(frameCount, MAX_PREDICTIONS)
+  const step = count === 1 ? 0 : (frameCount - 1) / (count - 1)
+  const indices = Array.from({ length: count }, (_, position) => Math.round(position * step))
+  const middle = Math.floor(count / 2)
+  return [...indices.slice(middle), ...indices.slice(0, middle)]
+}
+
+export const classifyImage = async (url: string, label: string, predict: Predict): Promise<boolean> => {
+  const response = await fetch(url, { signal: AbortSignal.timeout(LOAD_TIMEOUT) })
+  if (!response.ok) throw new Error(`Image request failed (${response.status})`)
+  const blob = await response.blob()
+  const type = await animationType(blob)
+  const objectUrl = URL.createObjectURL(blob)
+  let decoder: ImageDecoder | undefined
+
+  try {
+    if (type === null) return await predict(await loadImage(objectUrl), label)
+    if (typeof ImageDecoder === 'undefined' || !await ImageDecoder.isTypeSupported(type)) {
+      throw new Error('Animation inspection is unavailable')
+    }
+
+    decoder = new ImageDecoder({
+      data: await blob.arrayBuffer(),
+      type,
+      desiredWidth: IMAGE_SIZE,
+      desiredHeight: IMAGE_SIZE,
+      preferAnimation: true
+    })
+    await decoder.tracks.ready
+    const track = decoder.tracks.selectedTrack
+    if (track === null) throw new Error('Image has no decodable track')
+    if (track.frameCount === 1) return await predict(await loadImage(objectUrl), label)
+    if (track.frameCount > MAX_DECODED_FRAMES) throw new Error('Animation frame limit reached')
+
+    const canvas = document.createElement('canvas')
+    canvas.width = canvas.height = IMAGE_SIZE
+    const context = canvas.getContext('2d')
+    if (context === null) throw new Error('Animation pixels unavailable')
+    let previous = ''
+
+    for (const index of sampleOrder(track.frameCount)) {
+      const { image } = await decoder.decode({ frameIndex: index })
+      try {
+        context.clearRect(0, 0, IMAGE_SIZE, IMAGE_SIZE)
+        context.drawImage(image, 0, 0, IMAGE_SIZE, IMAGE_SIZE)
+      } finally {
+        image.close()
+      }
+      const pixels = canvas.toDataURL('image/png')
+      // A still stretch of the animation is not worth asking about twice.
+      if (pixels === previous) continue
+      previous = pixels
+      if (await predict(await loadImage(pixels), `${label} frame ${index}`)) return true
+    }
+    return false
+  } finally {
+    decoder?.close()
+    URL.revokeObjectURL(objectUrl)
+  }
+}

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -21,13 +21,12 @@ import {
 import { DEFAULT_TRAINED_MODEL, TrainedModel } from '../utils/models'
 import { withTimeout } from '../utils/withTimeout'
 
+import { classifyImage } from './classifyImage'
 import { BinaryClassifier } from './classifiers/BinaryClassifier'
 import { Classifier } from './classifiers/Classifier'
 import { NsfwjsClassifier } from './classifiers/NsfwjsClassifier'
 import { readRestartState, saveRestartState } from './restartState'
 
-const IMAGE_SIZE = 224
-const LOADING_TIMEOUT = 1000
 const DEFAULT_FILTER_STRICTNESS = 55
 const MAX_LOAD_ATTEMPTS = 5
 
@@ -39,7 +38,7 @@ const WEBGL_PROBE_TIMEOUT = 3000
 // Cap a single classification. Predictions are serialised through `enqueue`, so
 // one stuck predict would wedge every queued image behind it (and the content
 // script's pending-hide stylesheet would leave them hidden). On timeout the
-// prediction rejects, the image is revealed, and the chain is freed.
+// prediction rejects, the caller receives an error, and the chain is freed.
 const PREDICTION_TIMEOUT = 10000
 // Fetching and compiling the .wasm binary is slower than probing WebGL.
 const WASM_INIT_TIMEOUT = 15000
@@ -108,7 +107,7 @@ const ensureBackend = async (): Promise<void> => {
 
   // Throw rather than leave currentBackend claiming a backend that isn't active.
   // bringUpClassifier retries, then every classification rejects and the content
-  // script reveals the images.
+  // script keeps the images filtered as unavailable.
   if (!(await setWasmBackend())) throw new Error('No usable TensorFlow.js backend')
   currentBackend = 'wasm'
 }
@@ -117,7 +116,7 @@ const ensureBackend = async (): Promise<void> => {
 // switching the live tfjs engine to WASM waits on it forever, so come back up in a
 // clean realm instead. reload() only schedules the navigation, so throw as well
 // rather than carry on in a realm about to go away. In-flight classifications are
-// dropped and the content script reveals those images.
+// dropped and the content script treats those images as unavailable.
 const restartOnWasm = (): never => {
   restarting = true
   saveRestartState(sessionStorage, {
@@ -250,28 +249,18 @@ const switchTo = async (id: TrainedModel): Promise<void> => {
   }
 }
 
-const loadImage = async (url: string, label: string): Promise<HTMLImageElement> => {
-  const image: HTMLImageElement = new Image(IMAGE_SIZE, IMAGE_SIZE)
-
-  return await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Image load timeout ${label}`)), LOADING_TIMEOUT)
-    image.crossOrigin = 'anonymous'
-    image.onload = () => { clearTimeout(timer); resolve(image) }
-    image.onerror = (err) => { clearTimeout(timer); reject(err) }
-    image.src = url
-  })
-}
-
-const classify = async (url: string, label: string): Promise<boolean> => {
-  ensureUp()
-  const image = await loadImage(url, label)
-
+const predictImage = async (image: HTMLImageElement, label: string): Promise<boolean> => {
   return await enqueue(async () => {
     if (activeClassifier === null) throw new Error('Model is not loaded')
     const prediction = activeClassifier.predict(image, label)
     inFlightPredict = prediction.catch(() => undefined)
     return await withTimeout(prediction, PREDICTION_TIMEOUT, 'Prediction')
   })
+}
+
+const classify = async (url: string, label: string): Promise<boolean> => {
+  ensureUp()
+  return await classifyImage(url, label, predictImage)
 }
 
 chrome.runtime.onMessage.addListener((

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -29,6 +29,7 @@ export class PredictionRequest {
 // unhide command back to the exact frame that reported the target.
 export const CONTEXT_TARGET = 'NSFW_FILTER_CONTEXT_TARGET'
 export const UNHIDE_IMAGE = 'NSFW_FILTER_UNHIDE'
+export const PAGE_HOST = 'NSFW_FILTER_PAGE_HOST'
 
 export type ContextTargetMessage = {
   type: typeof CONTEXT_TARGET
@@ -70,6 +71,7 @@ export class PredictionResponse {
   public readonly result: boolean
   public readonly message: string
   public readonly url: string
+  public readonly error?: string
 
   constructor (result: boolean, url: string, error?: string) {
     const message = typeof error === 'string' && error.length > 0
@@ -79,5 +81,6 @@ export class PredictionResponse {
     this.url = url
     this.result = result
     this.message = message
+    this.error = error
   }
 }

--- a/test/e2e/backgroundImage.test.js
+++ b/test/e2e/backgroundImage.test.js
@@ -70,9 +70,18 @@ describe('CSS background images', () => {
     }
   })
 
-  test('ignores an element with no background image', async () => {
+  // Releasing the pending rule needs a status on every element the walk visits,
+  // so an element with no background of its own is tagged sfw rather than left
+  // alone. Nothing else about it may change: no background introduced, no
+  // declaration written onto it, and its own text stays visible.
+  test('leaves an element with no background image untouched', async () => {
     const plain = await read(page, 'plain')
-    expect(plain.status).toBeNull()
+    expect(plain.status).toBe('sfw')
+    expect(plain.backgroundImage).toBe('none')
+    expect(plain.textVisibility).toBe('visible')
+    expect(await page.evaluate(() =>
+      document.getElementById('plain').getAttribute('style')
+    )).toBeNull()
   })
 
   // A virtualized list swaps the class and the same element shows different
@@ -176,13 +185,41 @@ describe('CSS background images', () => {
     expect(shorthand).toContain('var(--photo)')
   })
 
+  // Every element the walk reaches carries a status, so the tag alone no longer
+  // marks the ones with a background to restore. Ask the page instead: an element
+  // is owed a background only where the author declared a url for it.
   test('leaves no background stuck missing or unprocessed', async () => {
-    const leftovers = await page.evaluate(() =>
-      [...document.querySelectorAll('[data-nsfw-filter-background-status]')].filter(element => {
-        const status = element.getAttribute('data-nsfw-filter-background-status')
-        return status === 'processing' || getComputedStyle(element).backgroundImage === 'none'
-      }).length
+    const stuck = await page.evaluate(() =>
+      document.querySelectorAll('[data-nsfw-filter-background-status="processing"]').length
     )
-    expect(leftovers).toBe(0)
+    expect(stuck).toBe(0)
+
+    const missing = await page.evaluate(() => {
+      const owed = new Set()
+      // An inline url, including one held in a custom property the shorthand reads.
+      for (const element of document.querySelectorAll('[style]')) {
+        if (element.getAttribute('style').includes('url(')) owed.add(element)
+      }
+      for (const sheet of document.styleSheets) {
+        let rules
+        try {
+          rules = sheet.cssRules
+        } catch {
+          continue // A cross-origin sheet tells us nothing about this page.
+        }
+        for (const rule of rules) {
+          if (!(rule instanceof CSSStyleRule) || !rule.style.cssText.includes('url(')) continue
+          try {
+            for (const element of document.querySelectorAll(rule.selectorText)) owed.add(element)
+          } catch {
+            continue // A selector this document cannot query matches nothing here.
+          }
+        }
+      }
+      return [...owed]
+        .filter(element => getComputedStyle(element).backgroundImage === 'none')
+        .map(element => element.id || element.tagName)
+    })
+    expect(missing).toEqual([])
   })
 })

--- a/test/e2e/fixtures/background.html
+++ b/test/e2e/fixtures/background.html
@@ -10,7 +10,7 @@
   <div id="sheet" class="card">card text</div>
   <!-- The same image, applied inline. -->
   <div id="inline" style="width: 128px; height: 128px; background-image: url('/icon.png')">inline text</div>
-  <!-- No background at all: must never be tagged or touched. -->
+  <!-- No background at all: tagged sfw to release the pending rule, nothing more. -->
   <div id="plain">plain text</div>
 </body>
 </html>

--- a/test/e2e/staticImage.test.js
+++ b/test/e2e/staticImage.test.js
@@ -1,15 +1,24 @@
 // Regression guard for the flash fix: an image present in the markup at
 // document_start must be hidden, classified, and revealed by the content
 // script's initial sweep. Served locally so the result is deterministic.
+const SETTLE_TIMEOUT = 60000
+
 describe('Static images present at load', () => {
   let page
 
   beforeAll(async () => {
     page = await global.__BROWSER__.newPage()
     await page.goto(global.__BASE_URL__, { waitUntil: 'domcontentloaded' })
-    // Settle until every tagged image is past the 'processing' state.
-    await global.getDocumentImageAttributes(page)
-  })
+    // The shared helper waits only on images already carrying a status, and an
+    // empty set satisfies it at once: it cannot tell "nothing left to do" from
+    // "registration has not started". This fixture knows which images it ships,
+    // so wait for each of them to be registered as well as settled.
+    await page.waitForFunction(() => document.images.length > 0 &&
+      [...document.images].every(image => {
+        const status = image.getAttribute('data-nsfw-filter-status')
+        return status !== null && status !== 'processing'
+      }), { timeout: SETTLE_TIMEOUT, polling: 250 })
+  }, SETTLE_TIMEOUT)
 
   afterAll(async () => {
     await page.close()

--- a/test/e2e/video.test.js
+++ b/test/e2e/video.test.js
@@ -30,7 +30,9 @@ const read = async (page, id) => await page.evaluate((id) => {
   const video = document.getElementById(id)
   return {
     status: video.getAttribute('data-nsfw-filter-status'),
-    visibility: getComputedStyle(video).visibility
+    visibility: getComputedStyle(video).visibility,
+    filter: getComputedStyle(video).filter,
+    paused: video.paused
   }
 }, id)
 
@@ -48,11 +50,8 @@ const classified = async (page, id) => await page.waitForFunction(
 // A posterless video is tagged 'sfw' before it is sampled, and reloading its
 // media starts that over, so the status alone says nothing about where a video
 // is: only a status that is not 'processing' with the element back on screen
-// means a round finished. Waiting for that also rides out the sample a playing
-// video takes every ten seconds of media time.
-// The snapshot comes back from the same evaluation that accepted it: a playing
-// video samples again every ten seconds of media time, so reading it over a
-// second round trip can land in the next hide.
+// means the initial check finished. Read both values together so a media change
+// cannot put the status and visibility snapshots out of sync.
 const settledStatus = async (page, id) => {
   const settled = await page.waitForFunction((id) => {
     const video = document.getElementById(id)
@@ -116,13 +115,14 @@ describe('Videos on the page', () => {
     expect(await statuses(page, 'tiny')).not.toContain('tiny:processing')
   })
 
-  // A cross-origin video without CORS plays but cannot be read back. Leaving it
-  // hidden would blank video the browser is willing to show.
-  test('reveals a video whose frames cannot be read', async () => {
+  // A failed pixel read cannot establish that the footage is safe.
+  test('blurs and pauses a video whose frames cannot be read', async () => {
     await waitForStatus(page, 'foreign', 'unavailable')
     const foreign = await read(page, 'foreign')
     expect(foreign.status).toBe('unavailable')
     expect(foreign.visibility).toBe('visible')
+    expect(foreign.filter).toBe('blur(25px)')
+    expect(foreign.paused).toBe(true)
   })
 
   test('picks up and classifies a video added after load', async () => {

--- a/test/jest.unit.config.js
+++ b/test/jest.unit.config.js
@@ -7,5 +7,6 @@ module.exports = {
     transform: {
         "^.+\\.[jt]sx?$": [ "ts-jest", { tsconfig: "test/tsconfig.json" } ]
     },
+    setupFilesAfterEnv: [ "./jest.unit.setup.js" ],
     testEnvironment: "node"
 }

--- a/test/jest.unit.setup.js
+++ b/test/jest.unit.setup.js
@@ -1,0 +1,17 @@
+// jsdom does not implement IntersectionObserver, and the filters use one to
+// judge media as it approaches the viewport. Report anything observed as on
+// screen; a test that needs finer control installs its own stub over this.
+class IntersectionObserverStub {
+    constructor (callback) {
+        this.callback = callback
+    }
+
+    observe (element) {
+        this.callback([{ target: element, isIntersecting: true }], this)
+    }
+
+    unobserve () {}
+    disconnect () {}
+}
+
+global.IntersectionObserver = IntersectionObserverStub

--- a/test/unit/BackgroundImageFilter.test.ts
+++ b/test/unit/BackgroundImageFilter.test.ts
@@ -136,7 +136,7 @@ describe('content => BackgroundImageFilter', () => {
     new BackgroundImageFilter().observe(element)
     intersect(element, true)
 
-    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
     expect(runtime.sent()).toBe(0)
   })
 
@@ -149,7 +149,7 @@ describe('content => BackgroundImageFilter', () => {
     new BackgroundImageFilter().observe(element)
     intersect(element, true)
 
-    expect(element.dataset.nsfwFilterBackgroundStatus).toBeUndefined()
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
     expect(runtime.sent()).toBe(0)
   })
 
@@ -175,9 +175,8 @@ describe('content => BackgroundImageFilter', () => {
     expect(element.dataset.nsfwFilterBackgroundStatus).toBe('processing')
   })
 
-  // Nothing downstream is guaranteed to answer. A background the page owns is
-  // not ours to keep off the screen.
-  test('restores the background when the background worker never answers', async () => {
+  // A failed request does not establish that the background is safe.
+  test('keeps an unavailable background hidden', async () => {
     jest.useFakeTimers()
     jest.spyOn(console, 'warn').mockImplementation(() => {})
     const { intersect } = stubIntersectionObserver()
@@ -193,8 +192,8 @@ describe('content => BackgroundImageFilter', () => {
     intersect(element, true)
     await jest.advanceTimersByTimeAsync(5000)
 
-    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('sfw')
-    expect(element.style.getPropertyValue('background-image')).toBe(`url("${IMAGE}")`)
+    expect(element.dataset.nsfwFilterBackgroundStatus).toBe('unavailable')
+    expect(element.style.getPropertyValue('background-image')).toBe('none')
   })
 
   test('restores every background it removed when filtering is turned off', async () => {

--- a/test/unit/DOMWatcher.test.ts
+++ b/test/unit/DOMWatcher.test.ts
@@ -3,6 +3,7 @@
  */
 import { DOMWatcher } from '../../src/content/DOMWatcher/DOMWatcher'
 import { IBackgroundImageFilter } from '../../src/content/Filter/BackgroundImageFilter'
+import { ICanvasFilter } from '../../src/content/Filter/CanvasFilter'
 import { IImageFilter, ImageFilter } from '../../src/content/Filter/ImageFilter'
 import { IVideoFilter } from '../../src/content/Filter/VideoFilter'
 
@@ -12,13 +13,25 @@ const makeFilter = (): IImageFilter => ({
   analyzeImage: jest.fn(),
   setSettings: jest.fn(),
   revealImage: jest.fn(),
-  checkStyleMutation: jest.fn()
+  checkStyleMutation: jest.fn(),
+  applyEffectToBlocked: jest.fn(),
+  revealAll: jest.fn()
 })
 
 const makeVideoFilter = (): IVideoFilter => ({
   analyzeVideo: jest.fn(),
   checkPoster: jest.fn(),
   revealVideo: jest.fn(),
+  checkStyleMutation: jest.fn(),
+  applyEffectToBlocked: jest.fn(),
+  revealAll: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn()
+})
+
+const makeCanvasFilter = (): ICanvasFilter => ({
+  observe: jest.fn(),
+  revealCanvas: jest.fn(),
   checkStyleMutation: jest.fn(),
   applyEffectToBlocked: jest.fn(),
   revealAll: jest.fn(),
@@ -45,16 +58,16 @@ describe('content => DOMWatcher => watch', () => {
     document.body.innerHTML = '<img id="a"><img id="b">'
     const filter = makeFilter()
 
-    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter()).watch()
 
     expect(filter.analyzeImage).toHaveBeenCalledTimes(2)
-    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'), false)
-    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('b'), false)
+    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'))
+    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('b'))
   })
 
   test('checks images added after watching starts', async () => {
     const filter = makeFilter()
-    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter()).watch()
 
     document.body.appendChild(document.createElement('img'))
     await flushMutations()
@@ -65,13 +78,13 @@ describe('content => DOMWatcher => watch', () => {
   test('reanalyzes an image when its src attribute changes', async () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
-    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch();
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter()).watch();
     (filter.analyzeImage as jest.Mock).mockClear()
 
     document.getElementById('a')!.setAttribute('src', 'http://example.com/a.jpg')
     await flushMutations()
 
-    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'), true)
+    expect(filter.analyzeImage).toHaveBeenCalledWith(document.getElementById('a'))
   })
 })
 
@@ -83,7 +96,7 @@ describe('content => DOMWatcher => start/stop live', () => {
     document.body.innerHTML = '<img id="a">'
     const filter = makeFilter()
 
-    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter())
+    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter())
     watcher.watch()
     watcher.watch()
 
@@ -92,7 +105,7 @@ describe('content => DOMWatcher => start/stop live', () => {
 
   test('unwatch stops reacting to later mutations', async () => {
     const filter = makeFilter()
-    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter())
+    const watcher = new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter())
     watcher.watch()
     watcher.unwatch();
     (filter.analyzeImage as jest.Mock).mockClear()
@@ -111,14 +124,19 @@ describe('content => DOMWatcher => style rewrites (issue #244)', () => {
   test('re-hides a blocked image after the page rewrites its style attribute', async () => {
     document.body.innerHTML = '<img id="a" src="http://example.com/a.jpg" width="200" height="200">'
     const image = document.getElementById('a') as HTMLImageElement
-    // Already classified nsfw and hidden, so the initial sweep skips it and no
-    // background prediction is needed for this test.
-    image.dataset.nsfwFilterStatus = 'nsfw'
-    image.style.visibility = 'hidden'
+    ;(global as unknown as { chrome: unknown }).chrome = {
+      runtime: {
+        lastError: undefined,
+        sendMessage: (_request: unknown, respond: (response: unknown) => void) =>
+          respond({ result: true })
+      }
+    }
 
     const filter = new ImageFilter()
     filter.setSettings({ filterEffect: 'hide' })
-    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter()).watch()
+    new DOMWatcher(filter, makeVideoFilter(), makeBackgroundFilter(), makeCanvasFilter()).watch()
+    await flushMutations()
+    expect(image.dataset.nsfwFilterStatus).toBe('nsfw')
 
     image.setAttribute('style', 'visibility: visible')
     await flushMutations()
@@ -133,7 +151,7 @@ describe('content => DOMWatcher => cascade changes', () => {
   test('re-reads the parent of an inserted sibling', async () => {
     document.body.innerHTML = '<div id="list"><div id="card"></div></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter()).watch()
 
     document.getElementById('list')?.prepend(document.createElement('div'))
     await flushMutations()
@@ -144,7 +162,7 @@ describe('content => DOMWatcher => cascade changes', () => {
   test('re-reads what is on screen when a stylesheet is removed', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter()).watch()
     ;(background.recheckVisible as jest.Mock).mockClear()
 
     document.getElementById('sheet')?.remove()
@@ -158,7 +176,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('re-reads what is on screen when a wrapper holding a stylesheet is removed', async () => {
     document.body.innerHTML = '<div id="wrapper"><style></style></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter()).watch()
     ;(background.recheckVisible as jest.Mock).mockClear()
 
     document.getElementById('wrapper')?.remove()
@@ -170,7 +188,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('re-reads what is on screen when an id change brings in a new rule', async () => {
     document.body.innerHTML = '<div id="card"></div>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter()).watch()
 
     const card = document.getElementById('card') as HTMLElement
     card.id = 'other'
@@ -184,7 +202,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('stops watching a stylesheet the page removed', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    new DOMWatcher(makeFilter(), makeVideoFilter(), background).watch()
+    new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter()).watch()
 
     const sheet = document.getElementById('sheet') as HTMLElement
     sheet.remove()
@@ -202,7 +220,7 @@ describe('content => DOMWatcher => stylesheet registrations', () => {
   test('stops watching stylesheets when watching stops', async () => {
     document.body.innerHTML = '<style id="sheet"></style>'
     const background = makeBackgroundFilter()
-    const watcher = new DOMWatcher(makeFilter(), makeVideoFilter(), background)
+    const watcher = new DOMWatcher(makeFilter(), makeVideoFilter(), background, makeCanvasFilter())
     watcher.watch()
     watcher.unwatch()
     ;(background.recheckVisible as jest.Mock).mockClear()

--- a/test/unit/Filter.test.ts
+++ b/test/unit/Filter.test.ts
@@ -91,7 +91,7 @@ afterEach(() => {
 })
 
 describe('content => Filter => analysis deadline', () => {
-  test('reveals an image the background never answers for', async () => {
+  test('keeps an image hidden when the background never answers', async () => {
     stubRuntime()
     const image = makeImage()
 
@@ -101,8 +101,8 @@ describe('content => Filter => analysis deadline', () => {
 
     await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
 
-    expect(image.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(image.style.visibility).toBe('visible')
+    expect(image.dataset.nsfwFilterStatus).toBe('unavailable')
+    expect(image.style.visibility).toBe('hidden')
   })
 
   test('keeps the image hidden until the deadline is actually reached', async () => {
@@ -138,13 +138,13 @@ describe('content => Filter => analysis deadline', () => {
     reply({ result: true, url: image.src })
     await jest.advanceTimersByTimeAsync(0)
 
-    expect(image.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(image.style.visibility).toBe('visible')
+    expect(image.dataset.nsfwFilterStatus).toBe('unavailable')
+    expect(image.style.visibility).toBe('hidden')
   })
 
   // Two <img> elements sharing a src are deduplicated onto one request, so the
   // deadline has to settle every waiter, not just the first.
-  test('reveals every image waiting on the same url', async () => {
+  test('keeps every image hidden when a shared request times out', async () => {
     stubRuntime()
     const first = makeImage()
     const second = makeImage()
@@ -154,12 +154,12 @@ describe('content => Filter => analysis deadline', () => {
     filter.analyzeImage(second)
     await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
 
-    expect(first.style.visibility).toBe('visible')
-    expect(second.style.visibility).toBe('visible')
+    expect(first.style.visibility).toBe('hidden')
+    expect(second.style.visibility).toBe('hidden')
   })
 
   // Giving up on an unreachable worker settles every waiter and stops retrying.
-  test('reveals every image when the background worker never comes back', async () => {
+  test('keeps every image hidden when the background worker never comes back', async () => {
     const { sent } = stubUnreachableRuntime()
     const first = makeImage()
     const second = makeImage()
@@ -169,8 +169,8 @@ describe('content => Filter => analysis deadline', () => {
     filter.analyzeImage(second)
     await jest.advanceTimersByTimeAsync(ANALYSIS_DEADLINE)
 
-    expect(first.style.visibility).toBe('visible')
-    expect(second.style.visibility).toBe('visible')
+    expect(first.style.visibility).toBe('hidden')
+    expect(second.style.visibility).toBe('hidden')
     expect(sent()).toBe(6)
   })
 
@@ -186,7 +186,7 @@ describe('content => Filter => analysis deadline', () => {
     await jest.advanceTimersByTimeAsync(5000)
 
     expect(runtime.sent()).toBe(1)
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('hidden')
   })
 
   // The runtime error for an abandoned request arrives while the same url is queued

--- a/test/unit/ImageFilter.test.ts
+++ b/test/unit/ImageFilter.test.ts
@@ -74,9 +74,12 @@ describe('content => ImageFilter => analyzeImage', () => {
   test('does not reprocess an already-tagged image', () => {
     const spy = stubAnalyze()
     const image = makeImage(200, 200)
+    const filter = new ImageFilter()
+    filter.analyzeImage(image)
+    spy.mockClear()
     image.dataset.nsfwFilterStatus = 'sfw'
 
-    new ImageFilter().analyzeImage(image, false)
+    filter.analyzeImage(image)
 
     expect(spy).not.toHaveBeenCalled()
   })
@@ -86,7 +89,7 @@ describe('content => ImageFilter => analyzeImage', () => {
     const image = makeImage(200, 200)
     image.dataset.nsfwFilterStatus = 'sfw'
 
-    new ImageFilter().analyzeImage(image, true)
+    new ImageFilter().analyzeImage(image)
 
     expect(image.dataset.nsfwFilterStatus).toBe('processing')
     expect(spy).toHaveBeenCalled()
@@ -97,7 +100,7 @@ describe('content => ImageFilter => analyzeImage', () => {
     const image = makeImage(20, 20)
     image.dataset.nsfwFilterStatus = 'nsfw'
 
-    new ImageFilter().analyzeImage(image, true)
+    new ImageFilter().analyzeImage(image)
 
     expect(image.dataset.nsfwFilterStatus).toBe('nsfw')
     expect(spy).not.toHaveBeenCalled()
@@ -183,7 +186,7 @@ describe('content => ImageFilter => checkStyleMutation', () => {
     filter.setSettings({ filterEffect: 'hide' })
     const image = makeImage(200, 200)
     image.dataset.nsfwFilterStatus = 'nsfw'
-    image.style.visibility = 'hidden'
+    image.style.setProperty('visibility', 'hidden', 'important')
     const spy = jest.spyOn(image.style, 'visibility', 'set')
 
     filter.checkStyleMutation(image)
@@ -239,7 +242,7 @@ describe('content => ImageFilter => revealAll', () => {
     new ImageFilter().revealAll()
 
     expect(image.style.filter).toBe('')
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
     expect(image.dataset.nsfwFilterStatus).toBeUndefined()
   })
 
@@ -284,7 +287,7 @@ describe('content => ImageFilter => revealImage', () => {
     new ImageFilter().revealImage(image)
 
     expect(image.style.filter).toBe('')
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
     expect(image.dataset.nsfwFilterStatus).toBe('sfw')
   })
 
@@ -324,7 +327,7 @@ describe('content => ImageFilter => revealImage', () => {
     filter.revealImage(image)
 
     expect(image.hidden).toBe(false)
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
 
     wrapper.remove()
   })
@@ -362,7 +365,7 @@ describe('content => ImageFilter => late verdicts', () => {
 
     filter.analyzeImage(image)
     image.src = 'http://example.com/b.jpg'
-    filter.analyzeImage(image, true)
+    filter.analyzeImage(image)
     runtime.release(true)
     await settle()
 
@@ -381,7 +384,7 @@ describe('content => ImageFilter => late verdicts', () => {
     await settle()
 
     expect(image.dataset.nsfwFilterStatus).toBeUndefined()
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
   })
 
   test('does not hide an image the user unhid while it was being classified', async () => {
@@ -396,7 +399,7 @@ describe('content => ImageFilter => late verdicts', () => {
     await settle()
 
     expect(image.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
   })
 
   // An image the page reparents while its verdict is out still carries the hidden
@@ -416,6 +419,6 @@ describe('content => ImageFilter => late verdicts', () => {
 
     expect(image.dataset.nsfwFilterStatus).toBe('sfw')
     expect(image.hidden).toBe(false)
-    expect(image.style.visibility).toBe('visible')
+    expect(image.style.visibility).toBe('')
   })
 })

--- a/test/unit/VideoFilter.test.ts
+++ b/test/unit/VideoFilter.test.ts
@@ -142,7 +142,7 @@ describe('content => VideoFilter', () => {
     expect(sent).toHaveLength(1)
     expect(sent[0].source).toBe(FRAME)
     expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // The frame is the payload, not the identity: a data url used as a key would be
@@ -184,9 +184,8 @@ describe('content => VideoFilter', () => {
     expect(video.paused).toBe(true)
   })
 
-  // Cross-origin footage the browser will play but not let us read. Leaving it
-  // hidden would blank video the page is entitled to show.
-  test('reveals a video whose frames cannot be read back', async () => {
+  // Cross-origin footage can play even when its pixels cannot be inspected.
+  test('keeps unreadable video hidden', async () => {
     stubCanvas('taint')
     const { sent } = stubRuntime()
     const video = makeVideo()
@@ -196,7 +195,8 @@ describe('content => VideoFilter', () => {
 
     expect(sent).toHaveLength(0)
     expect(video.dataset.nsfwFilterStatus).toBe('unavailable')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('hidden')
+    expect(video.paused).toBe(true)
   })
 
   test('stops sampling a video it cannot read', async () => {
@@ -251,8 +251,8 @@ describe('content => VideoFilter', () => {
     runtime.release()
     await settle()
 
-    expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.dataset.nsfwFilterStatus).toBe('processing')
+    expect(video.style.visibility).toBe('hidden')
   })
 
   // New media still has to end up with a status, or the stylesheet that hides
@@ -267,7 +267,7 @@ describe('content => VideoFilter', () => {
     await settle()
 
     expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // A frame is the stronger evidence and can land first. The poster reply that
@@ -353,7 +353,7 @@ describe('content => VideoFilter', () => {
     filter.analyzeVideo(video)
 
     expect(video.dataset.nsfwFilterStatus).toBeUndefined()
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // A paused video still shows its first decoded frame.
@@ -407,7 +407,7 @@ describe('content => VideoFilter', () => {
     await settle()
 
     expect(video.dataset.nsfwFilterStatus).toBeUndefined()
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
     expect(video.paused).toBe(false)
   })
 
@@ -437,7 +437,7 @@ describe('content => VideoFilter', () => {
 
     expect(runtime.sent).toHaveLength(1)
     expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // Filtering off, then on again: the same elements have to start being sampled
@@ -493,7 +493,7 @@ describe('content => VideoFilter', () => {
     await settle()
 
     expect(runtime.sent).toHaveLength(1)
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // Turning filtering off retires the user's unhide with everything else. Keeping
@@ -515,7 +515,7 @@ describe('content => VideoFilter', () => {
 
     expect(runtime.sent.filter(({ url }) => url.endsWith('poster.jpg'))).toHaveLength(2)
     expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // The poster is the only thing on screen for a video with nothing decoded, so
@@ -535,7 +535,7 @@ describe('content => VideoFilter', () => {
     await settle()
 
     expect(video.dataset.nsfwFilterStatus).toBe('sfw')
-    expect(video.style.visibility).toBe('visible')
+    expect(video.style.visibility).toBe('')
   })
 
   // A poster and a frame are two requests racing. A frame that cannot be read

--- a/test/unit/VideoFilter.test.ts
+++ b/test/unit/VideoFilter.test.ts
@@ -251,8 +251,8 @@ describe('content => VideoFilter', () => {
     runtime.release()
     await settle()
 
-    expect(video.dataset.nsfwFilterStatus).toBe('processing')
-    expect(video.style.visibility).toBe('hidden')
+    expect(video.dataset.nsfwFilterStatus).toBe('sfw')
+    expect(video.style.visibility).toBe('')
   })
 
   // New media still has to end up with a status, or the stylesheet that hides

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -9,6 +9,7 @@ const PATHS = {
 module.exports = {
     entry: {
         content: `${PATHS.src}/content/content.ts`,
+        mediaGuard: `${PATHS.src}/content/mediaGuard.ts`,
         background: `${PATHS.src}/background/background.ts`,
         offscreen: `${PATHS.src}/offscreen/offscreen.ts`,
         popup: `${PATHS.src}/popup/index.tsx`,


### PR DESCRIPTION
#### Changes

Related: #262, #252

Media could reach the screen unfiltered through paths nothing in the image or
video code sees. I routed each of them into the existing classifier and queue
rather than adding a second pipeline.

**Newly inspected:** canvas, SVG `<image>`, open and closed shadow roots,
backgrounds on `::before`/`::after`, the later frames of animated GIF/WebP/APNG,
and iframes — which were previously skipped entirely and now follow the top
page's allowlist. Also `<picture>`/`srcset` reselection, which changes what an
image displays without touching `src`, and background swaps driven only by
`:hover`.

Ordinary element backgrounds were already handled by `BackgroundImageFilter`;
this extends that class rather than replacing it.

**Deliberate behaviour changes, called out because they are debatable:**

1. **Unreadable media is blocked, not shown.** A cross-origin video without
   CORS, a wedged model or a failed decode now leaves the element suppressed.
   This reverses the previous "left visible rather than blanked" choice. It can
   suppress safe media that cannot be read.
2. **Video sampling moved from 10s to 1s of media time.** This shortens the
   exposure window when footage turns explicit, and is the main added running
   cost. Sampling is still one frame in flight per document.
3. **Elements with no background image are tagged `sfw`.** The pending-hide
   rule keeps a background suppressed until the element carries a verdict, so
   releasing it requires a tag. That is why a `background`-free element, and
   `HTML`/`BODY`, now carry `data-nsfw-filter-background-status`.
4. **A MAIN-world script** reports canvas drawing and shadow-root creation so
   they can be caught before paint. It classifies nothing and decides nothing.
   It does replace native function identity on the canvas prototypes.
5. **Media retrieval.** The animation helper fetches image bytes to decode
   frames. The existing offscreen loader already retrieved media by assigning
   `image.src`; this changes how, not whether. No CDN, remote font, analytics,
   remote inference or model download is added. I am flagging it explicitly
   against the "no runtime fetches" line in CONTRIBUTING rather than claiming
   literal compliance.
6. **Revealing an element removes the declarations the filter wrote** instead
   of setting `visibility: visible`, so a page that hides its own images keeps
   them hidden.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] `npm run lint` passes
- [x] `npm run test` passes (unit and end-to-end)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering support for canvas content and SVG images.
  * Extended media protection to shadow DOM content, including dynamically created shadow roots.
  * Improved animated image analysis by sampling multiple frames.
  * The unhide context-menu option is now available in all contexts.

* **Bug Fixes**
  * Media that cannot be analyzed now remains protected instead of being revealed.
  * Improved video handling when frames or posters cannot be read, including picture-in-picture playback.
  * Improved background-image classification and pending-hide behavior.
  * Reduced unnecessary page scanning while maintaining media protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->