### PR TITLE
fix: stop a slow or lost answer from unfiltering an image

### DIFF
--- a/src/background/OffscreenModel.ts
+++ b/src/background/OffscreenModel.ts
@@ -22,25 +22,30 @@ class RealmGoneError extends Error {}
 // classification in flight. The service worker sees a closed port, which is
 // indistinguishable from a real failure, and a failure reaches the page as "safe",
 // so the first page open on a machine without a usable GPU had every image waved
-// through. Send those again until the new realm answers. The budget covers a
-// reload plus a model load and still leaves room under the content script's 60s
-// deadline. Bounded by wall clock rather than by a count, so a realm that answers
-// slowly can't stretch it.
+// through. Send those again until the new realm answers. The budget is how long
+// resends stay admissible, not a deadline on the answer: a reload plus a model
+// load has to fit inside it. The clock starts when the loss is first seen, not when
+// the classification was sent, because a slow bring-up can burn a request-relative
+// budget before the restart it is meant to cover has even happened.
 const REALM_RETRY_DELAY = 1000
-const REALM_RETRY_BUDGET = 30000
+const REALM_RETRY_WINDOW = 30000
 
 export class OffscreenModel implements IOffscreenModel {
   public async predict (url: string, label?: string): Promise<boolean> {
     const request: OffscreenRequest = { target: 'offscreen', type: 'CLASSIFY', url, label }
 
-    const deadline = Date.now() + REALM_RETRY_BUDGET
+    let deadline = 0
 
     for (;;) {
       try {
         return await this.classify(request)
       } catch (error) {
-        if (!(error instanceof RealmGoneError) || Date.now() >= deadline) throw error
+        if (!(error instanceof RealmGoneError)) throw error
+        if (deadline === 0) deadline = Date.now() + REALM_RETRY_WINDOW
+
         await new Promise(resolve => setTimeout(resolve, REALM_RETRY_DELAY))
+        // Checked after the wait as well: the window can close while sleeping.
+        if (Date.now() >= deadline) throw error
       }
     }
   }

--- a/src/background/OffscreenModel.ts
+++ b/src/background/OffscreenModel.ts
@@ -1,6 +1,7 @@
 import {
   OffscreenClassifyResponse,
-  OffscreenRequest
+  OffscreenRequest,
+  RESTARTING_MESSAGE
 } from '../utils/messages'
 import { TrainedModel } from '../utils/models'
 
@@ -13,24 +14,56 @@ export type IOffscreenModel = {
   setSettings: (filterStrictness: number, logging: boolean, trainedModel: TrainedModel) => void
 }
 
+// A classification that dies with the offscreen realm, as opposed to one the model
+// answered. Only these are worth sending again.
+class RealmGoneError extends Error {}
+
+// Coming up on WASM means reloading the offscreen document, which kills every
+// classification in flight. The service worker sees a closed port, which is
+// indistinguishable from a real failure, and a failure reaches the page as "safe",
+// so the first page open on a machine without a usable GPU had every image waved
+// through. Send those again until the new realm answers. The budget covers a
+// reload plus a model load and still leaves room under the content script's 60s
+// deadline. Bounded by wall clock rather than by a count, so a realm that answers
+// slowly can't stretch it.
+const REALM_RETRY_DELAY = 1000
+const REALM_RETRY_BUDGET = 30000
+
 export class OffscreenModel implements IOffscreenModel {
   public async predict (url: string, label?: string): Promise<boolean> {
     const request: OffscreenRequest = { target: 'offscreen', type: 'CLASSIFY', url, label }
 
+    const deadline = Date.now() + REALM_RETRY_BUDGET
+
+    for (;;) {
+      try {
+        return await this.classify(request)
+      } catch (error) {
+        if (!(error instanceof RealmGoneError) || Date.now() >= deadline) throw error
+        await new Promise(resolve => setTimeout(resolve, REALM_RETRY_DELAY))
+      }
+    }
+  }
+
+  private async classify (request: OffscreenRequest): Promise<boolean> {
     return await new Promise((resolve, reject) => {
       chrome.runtime.sendMessage(request, (response: OffscreenClassifyResponse | undefined) => {
-        if (chrome.runtime.lastError !== null && chrome.runtime.lastError !== undefined) {
-          reject(new Error(chrome.runtime.lastError.message))
+        if (chrome.runtime.lastError !== undefined) {
+          reject(new RealmGoneError(chrome.runtime.lastError.message))
           return
         }
 
         if (response === undefined) {
-          reject(new Error('No response from offscreen document'))
+          reject(new RealmGoneError('No response from offscreen document'))
           return
         }
 
         if (typeof response.error === 'string' && response.error.length > 0) {
-          reject(new Error(response.error))
+          // The document answers this one before it navigates away, so it is the
+          // same loss as a closed port, just reported a moment earlier.
+          reject(response.error === RESTARTING_MESSAGE
+            ? new RealmGoneError(response.error)
+            : new Error(response.error))
           return
         }
 

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -27,7 +27,11 @@ import { NsfwjsClassifier } from './classifiers/NsfwjsClassifier'
 import { readRestartState, saveRestartState } from './restartState'
 
 const IMAGE_SIZE = 224
-const LOADING_TIMEOUT = 1000
+// The offscreen document fetches the image again, CORS-anonymous so it can read
+// the pixels. 1s came from Manifest V2, where two loads ran at a time and a stuck
+// one starved the other slot; MV3 loads them in parallel, so a budget that tight
+// only turns a slow image into an unfiltered one.
+const LOADING_TIMEOUT = 10000
 const DEFAULT_FILTER_STRICTNESS = 55
 const MAX_LOAD_ATTEMPTS = 5
 

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -4,7 +4,7 @@
 // return a boolean. We prefer the WebGL (GPU) backend, the one the MV2 background
 // page used, and fall back to single-threaded WASM (CPU) when no usable GPU is
 // available. trySetWebglBackend() and setWasmBackend() cover the CSP details, and
-// restartOnWasm() covers why the fallback reloads the document.
+// restartRealm() covers why the fallback reloads the document.
 //
 // This file owns the shared tfjs backend and serializes work; the actual model
 // (weights, preprocessing, decision) lives behind a Classifier so the user can
@@ -44,12 +44,11 @@ const WEBGL_PROBE_TIMEOUT = 3000
 // Cap a single classification. Predictions are serialised through `enqueue`, so
 // one stuck predict would wedge every queued image behind it (and the content
 // script's pending-hide stylesheet would leave them hidden). On timeout the
-// prediction rejects, the image is revealed, and the chain is freed -- which makes
-// this a budget for a wedged prediction, not a slow one. ViT on WASM takes about
-// three seconds per image on an idle machine and several times that on a busy one,
-// and a prediction cut short is an unfiltered image, so keep well clear of both
-// while staying under the content script's 60s deadline.
-const PREDICTION_TIMEOUT = 30000
+// prediction rejects, the image is revealed, and the chain is freed. It covers less
+// than it looks like: predict() runs its graph synchronously and only then returns
+// a promise, so on WASM most of the inference is already over before this timer is
+// armed.
+const PREDICTION_TIMEOUT = 10000
 // Fetching and compiling the .wasm binary is slower than probing WebGL.
 const WASM_INIT_TIMEOUT = 15000
 
@@ -97,7 +96,7 @@ const setWasmBackend = async (): Promise<boolean> => {
 }
 
 // The tfjs backend is global and picked once per document: WebGL, or WASM after a
-// restart. It is never switched in place; see restartOnWasm.
+// restart. It is never switched in place; see restartRealm.
 let currentBackend: 'webgl' | 'wasm' | null = null
 let restarting = false
 
@@ -112,7 +111,7 @@ const ensureBackend = async (): Promise<void> => {
       currentBackend = 'webgl'
       return
     }
-    restartOnWasm()
+    restartRealm()
   }
 
   // Throw rather than leave currentBackend claiming a backend that isn't active.
@@ -122,12 +121,12 @@ const ensureBackend = async (): Promise<void> => {
   currentBackend = 'wasm'
 }
 
-// A WebGL probe or warm-up that timed out is still running on the GPU, and
-// switching the live tfjs engine to WASM waits on it forever, so come back up in a
-// clean realm instead. reload() only schedules the navigation, so throw as well
-// rather than carry on in a realm about to go away. In-flight classifications are
-// dropped and the content script reveals those images.
-const restartOnWasm = (): never => {
+// Work that timed out may still be running underneath, and switching the live
+// tfjs engine can wait on it indefinitely, so come back up in a clean realm
+// instead, carrying the settings the service worker already pushed. Callers must
+// not carry on afterwards: reload() only schedules the navigation, hence the
+// throw. In-flight classifications are dropped; the service worker sends them again.
+const restartRealm = (): never => {
   restarting = true
   saveRestartState(sessionStorage, {
     filterStrictness: pendingStrictness,
@@ -150,8 +149,10 @@ let pendingLogging = restartState?.logging ?? false
 if (pendingLogging) logger.enable()
 
 // Serialise predictions AND model switches on one chain so a switch never
-// disposes a model out from under an in-flight prediction (model concurrency =
-// 1). Image *loading* still runs in parallel; it happens before joining here.
+// disposes a model out from under an in-flight prediction. The chain orders the
+// queued operations, not the inference underneath one that has already timed
+// out; switchTo waits that out separately. Image *loading* still runs in
+// parallel; it happens before joining here.
 let opChain: Promise<unknown> = Promise.resolve()
 
 const enqueue = async <T>(op: () => Promise<T>): Promise<T> => {
@@ -162,16 +163,21 @@ const enqueue = async <T>(op: () => Promise<T>): Promise<T> => {
 
 // A prediction that exceeds PREDICTION_TIMEOUT rejects and frees the chain (so
 // one stuck image can't wedge the rest), but the underlying predict() may still
-// be running against the model. Hold every one that hasn't settled so switchTo()
-// can wait them all out before disposing — otherwise a queued switch would dispose
-// tensors mid-inference. Keeping only the newest would miss an older one that is
-// still running behind it.
-const inFlightPredictions = new Set<Promise<unknown>>()
+// be running against the model. Hold every one that hasn't settled, per classifier,
+// so a switch waits out the model it is about to dispose and no other. Keeping only
+// the newest would miss an older one still running behind it; keeping one set for
+// the whole realm would make a single stalled prediction delay every later switch.
+const inFlightPredictions = new WeakMap<Classifier, Set<Promise<unknown>>>()
 
-const trackPrediction = (prediction: Promise<unknown>): void => {
+// How long a switch waits for the model it is replacing to go quiet.
+const DISPOSE_WAIT_TIMEOUT = 30000
+
+const trackPrediction = (classifier: Classifier, prediction: Promise<unknown>): void => {
   const settled = prediction.catch(() => undefined)
-  inFlightPredictions.add(settled)
-  void settled.finally(() => inFlightPredictions.delete(settled))
+  const pending = inFlightPredictions.get(classifier) ?? new Set<Promise<unknown>>()
+  inFlightPredictions.set(classifier, pending)
+  pending.add(settled)
+  void settled.finally(() => pending.delete(settled))
 }
 
 const createClassifier = (id: TrainedModel): Classifier => {
@@ -195,7 +201,7 @@ const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
       const ok = await classifier.load(true)
       if (!ok && currentBackend === 'webgl') {
         logger.log('WebGL cannot run the model; restarting the offscreen document on WASM')
-        restartOnWasm()
+        restartRealm()
       }
       if (!ok) {
         classifier.dispose()
@@ -213,7 +219,7 @@ const bringUpClassifier = async (id: TrainedModel): Promise<Classifier> => {
       // Out of retries on WebGL. A load that keeps failing there may be waiting on
       // GPU work we can't cancel, so drop the realm rather than report no model.
       if (attempts >= MAX_LOAD_ATTEMPTS) {
-        if (currentBackend === 'webgl') restartOnWasm()
+        if (currentBackend === 'webgl') restartRealm()
         throw error
       }
       await new Promise(resolve => setTimeout(resolve, 200))
@@ -250,14 +256,26 @@ const ensureUp = (): void => {
   }).catch(() => undefined)
 }
 
-// Dispose the old model BEFORE loading the new one (never both resident). Safe
-// because this runs on the same chain as predictions, so nothing is mid-predict.
+// Dispose the old model before loading the new one, so the two are never both
+// resident.
 const switchTo = async (id: TrainedModel): Promise<void> => {
   const previous = activeClassifier
   activeClassifier = null
-  // A timed-out prediction may still be running on `previous`; let them all settle
-  // so we never dispose the model out from under an in-flight inference.
-  await Promise.all(inFlightPredictions)
+  // A timed-out prediction may still be running on `previous`; let it settle so we
+  // never free tensors an inference is still reading.
+  const pending = previous === null ? [] : inFlightPredictions.get(previous) ?? []
+  const quiet = await withTimeout(Promise.all(pending), DISPOSE_WAIT_TIMEOUT, 'Pending predictions')
+    .then(() => true)
+    .catch(() => false)
+
+  // Neither option is safe here: disposing frees tensors an inference may still be
+  // reading, and keeping the model leaves one nothing will ever dispose. Drop the
+  // realm instead, which releases both, and let the service worker send the
+  // classifications lost with it again.
+  if (!quiet) {
+    logger.log('A prediction is still running long after its timeout; restarting the offscreen document')
+    restartRealm()
+  }
   previous?.dispose()
   try {
     activeClassifier = await bringUpOrFallback(id)
@@ -291,7 +309,7 @@ const classify = async (url: string, label: string): Promise<boolean> => {
     if (restarting) throw new Error(RESTARTING_MESSAGE)
     if (activeClassifier === null) throw new Error('Model is not loaded')
     const prediction = activeClassifier.predict(image, label)
-    trackPrediction(prediction)
+    trackPrediction(activeClassifier, prediction)
     return await withTimeout(prediction, PREDICTION_TIMEOUT, 'Prediction')
   })
 }

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -16,7 +16,8 @@ import { setWasmPaths } from '@tensorflow/tfjs-backend-wasm'
 import { Logger } from '../utils/Logger'
 import {
   OffscreenClassifyResponse,
-  OffscreenRequest
+  OffscreenRequest,
+  RESTARTING_MESSAGE
 } from '../utils/messages'
 import { DEFAULT_TRAINED_MODEL, TrainedModel } from '../utils/models'
 import { withTimeout } from '../utils/withTimeout'
@@ -43,8 +44,12 @@ const WEBGL_PROBE_TIMEOUT = 3000
 // Cap a single classification. Predictions are serialised through `enqueue`, so
 // one stuck predict would wedge every queued image behind it (and the content
 // script's pending-hide stylesheet would leave them hidden). On timeout the
-// prediction rejects, the image is revealed, and the chain is freed.
-const PREDICTION_TIMEOUT = 10000
+// prediction rejects, the image is revealed, and the chain is freed -- which makes
+// this a budget for a wedged prediction, not a slow one. ViT on WASM takes about
+// three seconds per image on an idle machine and several times that on a busy one,
+// and a prediction cut short is an unfiltered image, so keep well clear of both
+// while staying under the content script's 60s deadline.
+const PREDICTION_TIMEOUT = 30000
 // Fetching and compiling the .wasm binary is slower than probing WebGL.
 const WASM_INIT_TIMEOUT = 15000
 
@@ -131,7 +136,7 @@ const restartOnWasm = (): never => {
   })
   location.reload()
 
-  throw new Error('Restarting the offscreen document on WASM')
+  throw new Error(RESTARTING_MESSAGE)
 }
 
 // --- The active model and the work queue ----------------------------------
@@ -157,9 +162,17 @@ const enqueue = async <T>(op: () => Promise<T>): Promise<T> => {
 
 // A prediction that exceeds PREDICTION_TIMEOUT rejects and frees the chain (so
 // one stuck image can't wedge the rest), but the underlying predict() may still
-// be running against the model. Track it so switchTo() can wait for it to settle
-// before disposing — otherwise a queued switch would dispose tensors mid-inference.
-let inFlightPredict: Promise<unknown> = Promise.resolve()
+// be running against the model. Hold every one that hasn't settled so switchTo()
+// can wait them all out before disposing — otherwise a queued switch would dispose
+// tensors mid-inference. Keeping only the newest would miss an older one that is
+// still running behind it.
+const inFlightPredictions = new Set<Promise<unknown>>()
+
+const trackPrediction = (prediction: Promise<unknown>): void => {
+  const settled = prediction.catch(() => undefined)
+  inFlightPredictions.add(settled)
+  void settled.finally(() => inFlightPredictions.delete(settled))
+}
 
 const createClassifier = (id: TrainedModel): Classifier => {
   const settings = { filterStrictness: pendingStrictness }
@@ -242,9 +255,9 @@ const ensureUp = (): void => {
 const switchTo = async (id: TrainedModel): Promise<void> => {
   const previous = activeClassifier
   activeClassifier = null
-  // A timed-out prediction may still be running on `previous`; let it settle so
-  // we never dispose the model out from under an in-flight inference.
-  await inFlightPredict
+  // A timed-out prediction may still be running on `previous`; let them all settle
+  // so we never dispose the model out from under an in-flight inference.
+  await Promise.all(inFlightPredictions)
   previous?.dispose()
   try {
     activeClassifier = await bringUpOrFallback(id)
@@ -271,9 +284,14 @@ const classify = async (url: string, label: string): Promise<boolean> => {
   const image = await loadImage(url, label)
 
   return await enqueue(async () => {
+    // ensureUp() swallows the restart so it can't reject an unrelated caller, which
+    // leaves the model null here. Say which it is: the service worker sends a lost
+    // classification again once the new realm is up, but only this one is worth
+    // sending again.
+    if (restarting) throw new Error(RESTARTING_MESSAGE)
     if (activeClassifier === null) throw new Error('Model is not loaded')
     const prediction = activeClassifier.predict(image, label)
-    inFlightPredict = prediction.catch(() => undefined)
+    trackPrediction(prediction)
     return await withTimeout(prediction, PREDICTION_TIMEOUT, 'Prediction')
   })
 }

--- a/src/offscreen/restartState.ts
+++ b/src/offscreen/restartState.ts
@@ -2,7 +2,7 @@ import { ILogger } from '../utils/Logger'
 import { TrainedModel } from '../utils/models'
 
 // The offscreen document cannot switch the TensorFlow.js backend in place, so it
-// reloads itself onto WASM instead (see restartOnWasm in offscreen.ts). The
+// reloads itself onto WASM instead (see restartRealm in offscreen.ts). The
 // reloaded document has no way back to the settings the service worker pushed,
 // because the worker is still running and won't push them again, so they are
 // handed over through sessionStorage.

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -81,3 +81,8 @@ export class PredictionResponse {
     this.message = message
   }
 }
+
+// A classification lost to the offscreen document reloading itself onto WASM,
+// rather than one the model answered. The service worker matches on it to decide
+// whether sending the image again is worth anything.
+export const RESTARTING_MESSAGE = 'Restarting the offscreen document on WASM'

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -62,6 +62,10 @@ const CONTENT_TYPES = {
   '.css': 'text/css'
 }
 
+// Long enough that the Manifest V2 budget of 1s would have given up on it, short
+// enough to stay well inside the current one.
+const SLOW_IMAGE_DELAY = 2500
+
 // A small static server so tests run against local fixtures instead of remote
 // hosts. Local images load instantly, which keeps classification deterministic.
 const startFixtureServer = async () => {
@@ -72,6 +76,18 @@ const startFixtureServer = async () => {
     if (url === '/icon.png') {
       res.writeHead(200, { 'Content-Type': 'image/png' })
       res.end(icon)
+      return
+    }
+
+    // The same icon, answered slower than a fast local file but well inside the
+    // offscreen document's load budget. slowImage.test.js uses it to prove a
+    // sluggish image is still classified rather than waved through.
+    if (url === '/slow-icon.png') {
+      // unref so the pending delay can't hold the test runner open past the suite.
+      setTimeout(() => {
+        res.writeHead(200, { 'Content-Type': 'image/png' })
+        res.end(icon)
+      }, SLOW_IMAGE_DELAY).unref()
       return
     }
 
@@ -116,4 +132,4 @@ const startFixtureServer = async () => {
   return { server, baseUrl: `http://localhost:${server.address().port}/` }
 }
 
-module.exports = { launchOptions, startFixtureServer }
+module.exports = { launchOptions, startFixtureServer, SLOW_IMAGE_DELAY }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -132,4 +132,4 @@ const startFixtureServer = async () => {
   return { server, baseUrl: `http://localhost:${server.address().port}/` }
 }
 
-module.exports = { launchOptions, startFixtureServer, SLOW_IMAGE_DELAY }
+module.exports = { launchOptions, startFixtureServer }

--- a/test/e2e/slowImage.test.js
+++ b/test/e2e/slowImage.test.js
@@ -1,0 +1,46 @@
+// The offscreen document fetches each image a second time to read its pixels. That
+// fetch used to get one second, a Manifest V2 number from when two loads shared the
+// queue. Anything slower came back as "no verdict", which the background reports as
+// `false` and the page treats as safe -- so on a slow connection images went
+// unfiltered. Ask the offscreen document directly, where a failure is still
+// distinguishable from a real verdict.
+
+const SETTLE_TIMEOUT = 40000
+
+const classify = async (url) => {
+  const worker = await global.__BROWSER__.waitForTarget(
+    target => target.type() === 'service_worker',
+    { timeout: SETTLE_TIMEOUT }
+  )
+  const session = await worker.createCDPSession()
+  const { result } = await session.send('Runtime.evaluate', {
+    expression: `new Promise(resolve => chrome.runtime.sendMessage(
+      { target: 'offscreen', type: 'CLASSIFY', url: '${url}' },
+      resolve
+    ))`,
+    awaitPromise: true,
+    returnByValue: true
+  })
+  await session.detach()
+
+  return result.value
+}
+
+describe('Slow images', () => {
+  test('classifies an image the server is slow to answer for', async () => {
+    expect(await classify(`${global.__BASE_URL__}slow-icon.png`)).toEqual({ result: false })
+  }, SETTLE_TIMEOUT)
+
+  // Guards the test above: if the fixture ever served instantly, it would pass
+  // without exercising anything.
+  test('serves that image slower than a local file', async () => {
+    const page = await global.__BROWSER__.newPage()
+    try {
+      const started = Date.now()
+      await page.goto(`${global.__BASE_URL__}slow-icon.png`, { waitUntil: 'load' })
+      expect(Date.now() - started).toBeGreaterThan(1000)
+    } finally {
+      await page.close()
+    }
+  }, SETTLE_TIMEOUT)
+})

--- a/test/e2e/slowImage.test.js
+++ b/test/e2e/slowImage.test.js
@@ -7,7 +7,25 @@
 
 const SETTLE_TIMEOUT = 40000
 
+// The offscreen document answers this and then reloads itself onto WASM, taking
+// every classification in flight with it. `OffscreenModel` sends those again; this
+// test speaks to the document directly, so it has to do the same.
+const RESTARTING = 'Restarting the offscreen document on WASM'
+
+const sleep = async (ms) => await new Promise(resolve => setTimeout(resolve, ms))
+
 const classify = async (url) => {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const response = await sendClassify(url)
+    // No response at all means the reload already closed the port.
+    if (response !== undefined && response.error !== RESTARTING) return response
+    await sleep(1000)
+  }
+
+  throw new Error('The offscreen document never came back from its restart')
+}
+
+const sendClassify = async (url) => {
   const worker = await global.__BROWSER__.waitForTarget(
     target => target.type() === 'service_worker',
     { timeout: SETTLE_TIMEOUT }
@@ -27,9 +45,11 @@ const classify = async (url) => {
 }
 
 describe('Slow images', () => {
+  // Long enough to cover a restart onto WASM, where the model has to load again
+  // before anything can be classified.
   test('classifies an image the server is slow to answer for', async () => {
     expect(await classify(`${global.__BASE_URL__}slow-icon.png`)).toEqual({ result: false })
-  }, SETTLE_TIMEOUT)
+  }, 90000)
 
   // Guards the test above: if the fixture ever served instantly, it would pass
   // without exercising anything.

--- a/test/unit/OffscreenModel.test.ts
+++ b/test/unit/OffscreenModel.test.ts
@@ -1,19 +1,29 @@
 import { OffscreenModel } from '../../src/background/OffscreenModel'
 import { RESTARTING_MESSAGE } from '../../src/utils/messages'
 
-// A classification lost to the offscreen document reloading itself onto WASM looks
-// exactly like a failed one, and a failure reaches the page as "safe". These cover
-// the difference: a lost classification is sent again, a real error is not.
+// A classification lost to the offscreen document reloading itself looks exactly
+// like a failed one, and a failure reaches the page as safe. These cover the
+// difference, and the window the proxy is allowed to keep sending in: it opens when
+// the loss is first seen, not when the classification was sent, so a slow bring-up
+// can't spend it before the restart it exists to cover.
 
+const WINDOW = 30000
+
+// What the offscreen document does with one request: answer, report an error, or
+// be gone. `after` delays the reply, so a realm that is merely slow is separable
+// from one that has died.
 type Reply = { result: boolean } | { error: string } | 'gone'
+type Scripted = { reply: Reply, after?: number }
 
-const chromeWith = (replies: Reply[]): { sent: number } => {
-  const state = { sent: 0 }
+type Harness = { sentAt: number[] }
 
-  const sendMessage = (_request: unknown, respond: (value: unknown) => void): void => {
-    const reply = replies[Math.min(state.sent, replies.length - 1)]
-    state.sent++
+const chromeWith = (script: Scripted[]): Harness => {
+  const harness: Harness = { sentAt: [] }
+  // Fake timers start the clock at the real time, so sends are recorded relative
+  // to the first one.
+  const start = Date.now()
 
+  const deliver = (reply: Reply, respond: (value: unknown) => void): void => {
     if (reply === 'gone') {
       // Chrome reports a closed port through lastError and an undefined response.
       chromeStub.runtime.lastError = { message: 'The message port closed' }
@@ -21,60 +31,96 @@ const chromeWith = (replies: Reply[]): { sent: number } => {
       chromeStub.runtime.lastError = undefined
       return
     }
-
     respond(reply)
+  }
+
+  const sendMessage = (_request: unknown, respond: (value: unknown) => void): void => {
+    const step = script[Math.min(harness.sentAt.length, script.length - 1)]
+    harness.sentAt.push(Date.now() - start)
+
+    if (step.after === undefined) deliver(step.reply, respond)
+    else setTimeout(() => { deliver(step.reply, respond) }, step.after)
   }
 
   const chromeStub = { runtime: { sendMessage, lastError: undefined as { message: string } | undefined } }
   Object.assign(global, { chrome: chromeStub })
 
-  return state
+  return harness
 }
 
 describe('background => OffscreenModel', () => {
   beforeEach(() => { jest.useFakeTimers() })
   afterEach(() => { jest.useRealTimers() })
 
-  // Each resend waits on a timer, so the test has to drive the clock forward for
-  // the loop to make progress. The outcome is captured as a value because the
-  // rejection would otherwise go unhandled while the clock runs.
+  // Resends wait on a timer, so the test drives the clock for the loop to make
+  // progress. The outcome is captured as a value because the rejection would
+  // otherwise go unhandled while the clock runs.
   const settle = async (prediction: Promise<boolean>): Promise<boolean | string> => {
     const outcome = prediction.then(result => result, (error: Error) => error.message)
-
-    for (let tick = 0; tick < 40; tick++) await jest.advanceTimersByTimeAsync(1000)
-
+    await jest.advanceTimersByTimeAsync(5 * 60 * 1000)
     return await outcome
   }
 
   test('Should send a classification again when the realm went away', async () => {
-    const state = chromeWith(['gone', 'gone', { result: true }])
-    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+    const harness = chromeWith([{ reply: 'gone' }, { reply: 'gone' }, { reply: { result: true } }])
 
-    expect(outcome).toBe(true)
-    expect(state.sent).toBe(3)
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe(true)
+    expect(harness.sentAt).toEqual([0, 1000, 2000])
   })
 
   test('Should send it again while the document is still on its way out', async () => {
-    const state = chromeWith([{ error: RESTARTING_MESSAGE }, { result: true }])
-    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+    const harness = chromeWith([{ reply: { error: RESTARTING_MESSAGE } }, { reply: { result: true } }])
 
-    expect(outcome).toBe(true)
-    expect(state.sent).toBe(2)
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe(true)
+    expect(harness.sentAt).toHaveLength(2)
   })
 
   test('Should not send it again when the model answered with an error', async () => {
-    const state = chromeWith([{ error: 'Image load timeout' }])
-    const outcome = await settle(new OffscreenModel().predict('http://localhost/slow.jpg'))
+    const harness = chromeWith([{ reply: { error: 'Image load timeout' } }])
 
-    expect(outcome).toBe('Image load timeout')
-    expect(state.sent).toBe(1)
+    expect(await settle(new OffscreenModel().predict('http://localhost/slow.jpg'))).toBe('Image load timeout')
+    expect(harness.sentAt).toHaveLength(1)
   })
 
-  test('Should give up rather than resend a realm that never comes back', async () => {
-    const state = chromeWith(['gone'])
-    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+  test('Should stop sending once the window has closed', async () => {
+    const harness = chromeWith([{ reply: 'gone' }])
 
-    expect(outcome).toBe('The message port closed')
-    expect(state.sent).toBeLessThan(40)
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe('The message port closed')
+    expect(Math.max(...harness.sentAt)).toBeLessThan(WINDOW)
+    expect(harness.sentAt).toHaveLength(WINDOW / 1000)
+  })
+
+  // The window has to start at the loss, not at the request: a bring-up slower than
+  // the window would otherwise use it all up before the restart even happened.
+  test('Should still resend when the realm is lost long after the request', async () => {
+    const harness = chromeWith([
+      { reply: { error: RESTARTING_MESSAGE }, after: 31000 },
+      { reply: { result: true } }
+    ])
+
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe(true)
+    expect(harness.sentAt).toEqual([0, 32000])
+  })
+
+  // A realm that accepts the request and takes its time is not a lost one.
+  test('Should wait out a slow answer rather than send again', async () => {
+    const harness = chromeWith([
+      { reply: 'gone' },
+      { reply: { result: true }, after: 35000 }
+    ])
+
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe(true)
+    expect(harness.sentAt).toEqual([0, 1000])
+  })
+
+  // A loss arriving just before the window shuts must not buy another send.
+  test('Should not send again when the wait would cross the window', async () => {
+    const harness = chromeWith([
+      { reply: 'gone' },
+      { reply: 'gone', after: 28500 }
+    ])
+
+    expect(await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))).toBe('The message port closed')
+    expect(harness.sentAt).toEqual([0, 1000])
   })
 })

--- a/test/unit/OffscreenModel.test.ts
+++ b/test/unit/OffscreenModel.test.ts
@@ -1,0 +1,80 @@
+import { OffscreenModel } from '../../src/background/OffscreenModel'
+import { RESTARTING_MESSAGE } from '../../src/utils/messages'
+
+// A classification lost to the offscreen document reloading itself onto WASM looks
+// exactly like a failed one, and a failure reaches the page as "safe". These cover
+// the difference: a lost classification is sent again, a real error is not.
+
+type Reply = { result: boolean } | { error: string } | 'gone'
+
+const chromeWith = (replies: Reply[]): { sent: number } => {
+  const state = { sent: 0 }
+
+  const sendMessage = (_request: unknown, respond: (value: unknown) => void): void => {
+    const reply = replies[Math.min(state.sent, replies.length - 1)]
+    state.sent++
+
+    if (reply === 'gone') {
+      // Chrome reports a closed port through lastError and an undefined response.
+      chromeStub.runtime.lastError = { message: 'The message port closed' }
+      respond(undefined)
+      chromeStub.runtime.lastError = undefined
+      return
+    }
+
+    respond(reply)
+  }
+
+  const chromeStub = { runtime: { sendMessage, lastError: undefined as { message: string } | undefined } }
+  Object.assign(global, { chrome: chromeStub })
+
+  return state
+}
+
+describe('background => OffscreenModel', () => {
+  beforeEach(() => { jest.useFakeTimers() })
+  afterEach(() => { jest.useRealTimers() })
+
+  // Each resend waits on a timer, so the test has to drive the clock forward for
+  // the loop to make progress. The outcome is captured as a value because the
+  // rejection would otherwise go unhandled while the clock runs.
+  const settle = async (prediction: Promise<boolean>): Promise<boolean | string> => {
+    const outcome = prediction.then(result => result, (error: Error) => error.message)
+
+    for (let tick = 0; tick < 40; tick++) await jest.advanceTimersByTimeAsync(1000)
+
+    return await outcome
+  }
+
+  test('Should send a classification again when the realm went away', async () => {
+    const state = chromeWith(['gone', 'gone', { result: true }])
+    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+
+    expect(outcome).toBe(true)
+    expect(state.sent).toBe(3)
+  })
+
+  test('Should send it again while the document is still on its way out', async () => {
+    const state = chromeWith([{ error: RESTARTING_MESSAGE }, { result: true }])
+    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+
+    expect(outcome).toBe(true)
+    expect(state.sent).toBe(2)
+  })
+
+  test('Should not send it again when the model answered with an error', async () => {
+    const state = chromeWith([{ error: 'Image load timeout' }])
+    const outcome = await settle(new OffscreenModel().predict('http://localhost/slow.jpg'))
+
+    expect(outcome).toBe('Image load timeout')
+    expect(state.sent).toBe(1)
+  })
+
+  test('Should give up rather than resend a realm that never comes back', async () => {
+    const state = chromeWith(['gone'])
+    const outcome = await settle(new OffscreenModel().predict('http://localhost/nsfw.jpg'))
+
+    expect(outcome).toBe('The message port closed')
+    expect(state.sent).toBeLessThan(40)
+  })
+})

--- a/test/unit/offscreen.test.ts
+++ b/test/unit/offscreen.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Drives the real offscreen orchestration -- the message listener, the op chain,
+// and switchTo -- against a stubbed tfjs and stubbed classifiers. Nothing here
+// tests inference; it tests what happens to a model when a prediction never
+// comes back.
+
+import { OffscreenClassifyResponse, OffscreenRequest, RESTARTING_MESSAGE } from '../../src/utils/messages'
+import { RESTART_KEY, RestartState } from '../../src/offscreen/restartState'
+import { TrainedModel } from '../../src/utils/models'
+
+type FakeClassifier = {
+  trainedModel: TrainedModel
+  load: jest.Mock
+  predict: jest.Mock
+  setSettings: jest.Mock
+  dispose: jest.Mock
+}
+
+type Registry = {
+  created: FakeClassifier[]
+  // Urls whose prediction hangs until settle() is called for them.
+  stuck: Set<string>
+  settle: (url: string) => void
+}
+
+const holding = new Map<string, (result: boolean) => void>()
+
+const mockRegistry: Registry = {
+  created: [],
+  stuck: new Set(),
+  settle: (url: string) => { holding.get(url)?.(false); holding.delete(url) }
+}
+
+const makeClassifier = (trainedModel: TrainedModel): FakeClassifier => {
+  const classifier: FakeClassifier = {
+    trainedModel,
+    load: jest.fn(async () => true),
+    predict: jest.fn(async (_image: unknown, url: string) => await new Promise<boolean>(resolve => {
+      if (!mockRegistry.stuck.has(url)) resolve(false)
+      else holding.set(url, resolve)
+    })),
+    setSettings: jest.fn(),
+    dispose: jest.fn()
+  }
+
+  mockRegistry.created.push(classifier)
+  return classifier
+}
+
+jest.mock('@tensorflow/tfjs', () => {
+  let backend = ''
+  return {
+    enableProdMode: jest.fn(),
+    env: () => ({ set: jest.fn() }),
+    getBackend: () => backend,
+    setBackend: jest.fn(async (name: string) => { backend = name; return true }),
+    tensor1d: () => ({ square: () => ({ data: async () => [1], dispose: jest.fn() }) }),
+    tidy: (fn: () => unknown) => fn()
+  }
+})
+
+jest.mock('@tensorflow/tfjs-backend-wasm', () => ({ setWasmPaths: jest.fn() }))
+
+jest.mock('../../src/offscreen/classifiers/BinaryClassifier', () => ({
+  BinaryClassifier: jest.fn(() => makeClassifier('ViT_NSFW_384'))
+}))
+
+jest.mock('../../src/offscreen/classifiers/NsfwjsClassifier', () => ({
+  NsfwjsClassifier: jest.fn(() => makeClassifier('MobileNet_v1.2'))
+}))
+
+type Listener = (
+  message: OffscreenRequest,
+  sender: unknown,
+  sendResponse: (response: OffscreenClassifyResponse) => void
+) => boolean | undefined
+
+let listener: Listener
+let consoleError: jest.SpyInstance
+
+// jsdom's location.reload is non-configurable and non-writable, so it can't be
+// mocked; it reports the navigation it won't perform through the virtual
+// console instead. Count those.
+const reloads = (): number => consoleError.mock.calls
+  .filter(call => call.some(arg => String(arg).includes('Not implemented: navigation')))
+  .length
+
+// Load offscreen.ts fresh so its module-scope state (the op chain, the restart
+// record it reads on start) belongs to this test alone.
+const loadOffscreen = (): void => {
+  jest.isolateModules(() => { require('../../src/offscreen/offscreen') })
+}
+
+const send = (message: OffscreenRequest): Promise<OffscreenClassifyResponse> => {
+  return new Promise(resolve => { listener(message, null, resolve) })
+}
+
+const classify = async (url: string): Promise<OffscreenClassifyResponse> => {
+  return await send({ target: 'offscreen', type: 'CLASSIFY', url })
+}
+
+// SET_SETTINGS never answers, so drive the listener and let the timers run.
+const setModel = (trainedModel: TrainedModel): void => {
+  listener({ target: 'offscreen', type: 'SET_SETTINGS', filterStrictness: 55, logging: false, trainedModel }, null, () => undefined)
+}
+
+const savedRestartState = (): RestartState | null => {
+  const saved = sessionStorage.getItem(RESTART_KEY)
+  return saved === null ? null : JSON.parse(saved) as RestartState
+}
+
+describe('offscreen => model lifecycle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockRegistry.created = []
+    mockRegistry.stuck = new Set()
+    holding.clear()
+    sessionStorage.clear()
+
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // jsdom never fires load for a src it cannot fetch, so hand the document an
+    // image that is always ready.
+    class ReadyImage {
+      public crossOrigin = ''
+      public onload: (() => void) | null = null
+      public onerror: ((error: unknown) => void) | null = null
+      public set src (_value: string) { setTimeout(() => this.onload?.(), 0) }
+    }
+    ;(global as unknown as { Image: unknown }).Image = ReadyImage
+
+    ;(global as unknown as { chrome: unknown }).chrome = {
+      runtime: {
+        getURL: (path: string) => `chrome-extension://test/${path}`,
+        onMessage: { addListener: (fn: Listener) => { listener = fn } }
+      }
+    }
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    consoleError.mockRestore()
+  })
+
+  it('Should dispose the model it replaces once its predictions have settled', async () => {
+    loadOffscreen()
+
+    const answer = classify('https://example.com/a.jpg')
+    await jest.advanceTimersByTimeAsync(100)
+    expect(await answer).toEqual({ result: false })
+
+    setModel('MobileNet_v1.2')
+    await jest.advanceTimersByTimeAsync(100)
+
+    expect(mockRegistry.created.map(c => c.trainedModel)).toEqual(['ViT_NSFW_384', 'MobileNet_v1.2'])
+    expect(mockRegistry.created[0].dispose).toHaveBeenCalled()
+    expect(reloads()).toBe(0)
+  })
+
+  it('Should restart the realm rather than dispose a model still running a prediction', async () => {
+    mockRegistry.stuck.add('https://example.com/stuck.jpg')
+    loadOffscreen()
+
+    const answer = classify('https://example.com/stuck.jpg')
+    await jest.advanceTimersByTimeAsync(10000)
+    expect(await answer).toEqual({ result: false, error: 'Prediction timed out after 10000ms' })
+
+    setModel('MobileNet_v1.2')
+    await jest.advanceTimersByTimeAsync(30000)
+
+    expect(mockRegistry.created[0].dispose).not.toHaveBeenCalled()
+    // The replacement must not load in a realm that is going away.
+    expect(mockRegistry.created).toHaveLength(1)
+    expect(reloads()).toBe(1)
+    expect(savedRestartState()).toEqual({
+      filterStrictness: 55,
+      trainedModel: 'MobileNet_v1.2',
+      logging: false
+    })
+  })
+
+  it('Should tell a classification queued behind the restart that the realm is going away', async () => {
+    mockRegistry.stuck.add('https://example.com/stuck.jpg')
+    loadOffscreen()
+
+    const stuck = classify('https://example.com/stuck.jpg')
+    await jest.advanceTimersByTimeAsync(10000)
+    await stuck
+
+    setModel('MobileNet_v1.2')
+    // Queued while the switch is still waiting, so it reaches the chain after the
+    // restart rather than being admitted afterwards.
+    const answer = classify('https://example.com/next.jpg')
+    await jest.advanceTimersByTimeAsync(30100)
+    expect(await answer).toEqual({ result: false, error: RESTARTING_MESSAGE })
+  })
+
+  it('Should dispose a model whose prediction settles after its own timeout', async () => {
+    mockRegistry.stuck.add('https://example.com/slow.jpg')
+    loadOffscreen()
+
+    const stuck = classify('https://example.com/slow.jpg')
+    await jest.advanceTimersByTimeAsync(10000)
+    expect(await stuck).toEqual({ result: false, error: 'Prediction timed out after 10000ms' })
+
+    setModel('MobileNet_v1.2')
+    await jest.advanceTimersByTimeAsync(5000)
+    // The image was slow, not lost: the model goes quiet inside the disposal wait.
+    mockRegistry.settle('https://example.com/slow.jpg')
+    await jest.advanceTimersByTimeAsync(100)
+
+    expect(reloads()).toBe(0)
+    expect(mockRegistry.created[0].dispose).toHaveBeenCalled()
+    expect(mockRegistry.created.map(c => c.trainedModel)).toEqual(['ViT_NSFW_384', 'MobileNet_v1.2'])
+  })
+
+  it('Should wait on an older prediction still running behind a settled newer one', async () => {
+    mockRegistry.stuck.add('https://example.com/stuck.jpg')
+    loadOffscreen()
+
+    const stuck = classify('https://example.com/stuck.jpg')
+    await jest.advanceTimersByTimeAsync(10000)
+    await stuck
+
+    // A second image answers normally on the same model. Tracking only the newest
+    // prediction would read that as the model being idle.
+    const next = classify('https://example.com/next.jpg')
+    await jest.advanceTimersByTimeAsync(100)
+    expect(await next).toEqual({ result: false })
+
+    setModel('MobileNet_v1.2')
+    await jest.advanceTimersByTimeAsync(30100)
+
+    expect(mockRegistry.created[0].dispose).not.toHaveBeenCalled()
+    expect(reloads()).toBe(1)
+  })
+})


### PR DESCRIPTION
Three ways a slow or lost answer became an unfiltered image.

**The offscreen document only got one second to fetch an image.** That number came from Manifest V2, where two loads shared the queue and a stuck one starved the other slot. MV3 loads them in parallel, so all it did was turn a slow image into an unfiltered one: the fetch gives up, the background reports no verdict, the page treats that as safe, and the URL is cached that way for the rest of the session. Serving an NSFW image 2.5s slow reproduces it, and reloading the page does not recover.

**Falling back to WASM waved through the whole first page.** Coming up on WASM means reloading the offscreen document, which kills every classification in flight. The service worker sees a closed port, which looks exactly like a failed classification, so every image on the page open at that moment was revealed. Reproduced on a machine with no usable GPU: four NSFW photographs, all four shown. The service worker now tells a lost classification from an answered one and sends the lost ones again once the new realm is up, bounded by a 30s budget.

**One stuck prediction could wedge the offscreen document for good.** A prediction that outruns its budget rejects and frees the chain, but the inference underneath keeps running, and only the newest one was tracked -- so a model switch could free tensors an older inference was still reading. Tracking all of them fixes that but introduces a worse failure if one never settles: the switch waits forever and every image queued behind it goes unanswered, which the page turns into unfiltered images rather than merely hidden ones. So the wait is bounded, and a switch that still can't get quiet reloads the offscreen document. Neither of the other two options is safe there -- disposing frees tensors an inference may still be reading, keeping the model leaves one nothing will ever dispose -- and dropping the realm releases both. The classifications lost with it are the ones the service worker now sends again.

#### Changes

- Give the offscreen image fetch 10s instead of 1s
- Resend classifications lost to the offscreen document restarting onto WASM, within a window that opens when the loss is first seen
- Wait out every unsettled prediction before disposing a model, bounded, and restart the document rather than dispose under live inference

#### Testing

- New `test/unit/OffscreenModel.test.ts` covers the resend: a lost classification is sent again, a real error is not, a realm that answers slowly is waited out rather than sent to again, and nothing is sent after the window closes. Verified to fail without the fix.
- New `test/e2e/slowImage.test.js` serves an image 2.5s slow and asks the offscreen document directly, where a failure is still distinguishable from a verdict. Fails on master with `Image load timeout`.
- New `test/unit/offscreen.test.ts` drives the real offscreen listener through the model-switch lifecycle: a model is disposed once its predictions settle, an older prediction still running behind a settled newer one is waited out, a model still running a prediction 30s past its timeout causes a restart rather than a disposal, and a classification already queued behind that restart is told the realm is going away.
- 143 unit tests, `tsc --noEmit`, and `eslint src/` clean.
- e2e on both the dev and production bundles: 32 passed, 8 skipped.
- Reproduced and re-verified both defects outside the repo with real photographs, headed Chrome, and a fresh profile.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification reliability when the offscreen processing environment restarts.
  * Classification now retries transient environment failures within a defined time window.
  * Added clearer status reporting when classification is interrupted by a restart.
  * Improved handling of slow-loading images and prediction timeouts.
  * Improved model switching to avoid interrupting active predictions.

* **Tests**
  * Added coverage for slow image classification, retry timing, prediction timeouts, and restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
